### PR TITLE
Make pyo3 dependency optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,10 @@ keywords = ["rpm", "reproducible-builds"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+default = ["python"]
+python = ["dep:pyo3"]
+
 [dependencies]
 anyhow = "1.0.12"
 chrono = "0.4.35"
@@ -19,7 +23,7 @@ clap = { version = "4.4.18", features = ["derive"] }
 indoc = "2.0.4"
 log = { version = "0.4", features = ["std"] }
 nix = { version = "0.28.0", features = ["fs", "socket"] }
-pyo3 = "0.20.0"
+pyo3 = { version = "0.20.0", optional = true }
 regex = { version = "1.10.0", default-features = false, features = ["std", "perf", "unicode-case"] }
 time = "0.3.34"
 walkdir = "2.5.0"

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -42,7 +42,7 @@ pub trait Processor {
 
 pub type HandlerBoxed = fn(&Rc<options::Config>) -> Box<dyn Processor>;
 
-pub const HANDLERS: [(&str, HandlerBoxed); 4] = [
+pub const HANDLERS: &[(&str, HandlerBoxed)] = &[
     ("ar",      ar::Ar::boxed),
     ("jar",     jar::Jar::boxed),
     ("javadoc", javadoc::Javadoc::boxed),
@@ -58,7 +58,7 @@ pub fn handler_names() -> Vec<&'static str> {
 pub fn make_handlers(config: &Rc<options::Config>) -> Result<Vec<Box<dyn Processor>>> {
     let mut handlers: Vec<Box<dyn Processor>> = vec![];
 
-    for (name, func) in &HANDLERS {
+    for (name, func) in HANDLERS {
         if config.handler_names.contains(name) {
             let mut handler = func(config);
             match handler.initialize() {

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -3,6 +3,8 @@
 pub mod ar;
 pub mod jar;
 pub mod javadoc;
+
+#[cfg(feature="python")]
 pub mod pyc;
 
 use anyhow::{Context, Result, anyhow};
@@ -46,6 +48,8 @@ pub const HANDLERS: &[(&str, HandlerBoxed)] = &[
     ("ar",      ar::Ar::boxed),
     ("jar",     jar::Jar::boxed),
     ("javadoc", javadoc::Javadoc::boxed),
+
+    #[cfg(feature="python")]
     ("pyc",     pyc::Pyc::boxed),
 ];
 

--- a/tests/test_handlers/mod.rs
+++ b/tests/test_handlers/mod.rs
@@ -1,5 +1,7 @@
 mod test_ar;
 mod test_javadoc;
+
+#[cfg(feature="python")]
 mod test_pyc;
 
 use anyhow::Result;


### PR DESCRIPTION
pyo3 pulls in libpython3.xx.so, which pulls in a fairly large package.