### PR TITLE
Disable unused zip and regex features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ indoc = "2.0.4"
 log = { version = "0.4", features = ["std"] }
 nix = { version = "0.28.0", features = ["fs", "socket"] }
 pyo3 = "0.20.0"
-regex = "1.10.0"
+regex = { version = "1.10.0", default-features = false, features = ["std", "perf", "unicode-case"] }
 time = "0.3.34"
 walkdir = "2.5.0"
 zip = { version = "0.6.0", default-features = false, features = ["deflate", "deflate-zlib", "time"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ pyo3 = "0.20.0"
 regex = "1.10.0"
 time = "0.3.34"
 walkdir = "2.5.0"
-zip = "0.6.0"
+zip = { version = "0.6.0", default-features = false, features = ["deflate", "deflate-zlib", "time"] }
 
 [dev-dependencies]
 tempfile = "3"


### PR DESCRIPTION
JAR archives use deflate, not bzip2 or zstd, and are not encrypted, so we can disable these features to avoid dependency bloat.