### PR TITLE
Update repology links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Build postprocessor to reset metadata fields for build reproducibility
 
-<a href="https://repology.org/project/rust:add-determinism/versions">
-    <img src="https://repology.org/badge/vertical-allrepos/rust:add-determinism.svg" alt="Packaging status" align="right">
+<a href="https://repology.org/project/add-determinism/versions">
+    <img src="https://repology.org/badge/vertical-allrepos/add-determinism.svg" alt="Packaging status" align="right">
 </a>
 
 This crate provides a binary `add-determinism` that one or more paths,


### PR DESCRIPTION
I've sent a patch to the repology project so all `add-determinism` packages get picked up correctly (instead of just `rust:add-determinism`), this caused the link to change though:

https://github.com/repology/repology-rules/pull/813