### PR TITLE
Use inline debug! in a few places

### DIFF
--- a/src/handlers/ar.rs
+++ b/src/handlers/ar.rs
@@ -48,11 +48,12 @@ impl super::Processor for Ar {
 
         output.write_all(&buf)?;
 
+        let ipath = io.input_path.display();
         loop {
             let pos = input.stream_position()?;
             let mut buf = [0; FILE_HEADER_LENGTH];
 
-            debug!("{}: reading file header at offset {}", io.input_path.display(), pos);
+            debug!("{ipath}: reading file header at offset {pos}");
 
             match input.read(&mut buf)? {
                 0 => break,

--- a/src/handlers/jar.rs
+++ b/src/handlers/jar.rs
@@ -67,8 +67,8 @@ impl super::Processor for Jar {
                         (dos_epoch.datepart() >> 8).try_into().unwrap(),
                     ];
 
-                    debug!("Epoch converted to zip::DateTime: {:?}", dos_epoch);
-                    debug!("Epoch as buffer: {:?}", ts);
+                    debug!("Epoch converted to zip::DateTime: {dos_epoch:?}");
+                    debug!("Epoch as buffer: {ts:?}");
 
                     // Open output again to adjust timestamps
                     let output_path = io.output_path.as_ref().unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ fn brp_check(config: &options::Config) -> Result<()> {
 
     let arg0 = env::args().next().unwrap();
 
-    debug!("Running as {}… (brp={})", arg0, if config.brp { "true" } else { "false" });
+    debug!("Running as {arg0}… (brp={})", if config.brp { "true" } else { "false" });
 
     if config.brp {
         let build_root = env::var("RPM_BUILD_ROOT")

--- a/src/multiprocess.rs
+++ b/src/multiprocess.rs
@@ -216,7 +216,7 @@ pub fn do_worker_work(config: options::Config) -> Result<()> {
             panic!("Empty input path");
         }
 
-        debug!("Will process {:?} (selected_handlers={})", input, selected_handlers);
+        debug!("Will process {input:?} (selected_handlers={selected_handlers})");
         let input_path = PathBuf::from(input);
 
         if let Err(e) =


### PR DESCRIPTION
This is both more concise and will avoid default rustfmt splitting it across lines. There's many more places that could be changed, this just shows a few.