### PR TITLE
Add --check

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ log = { version = "0.4", features = ["std"] }
 nix = { version = "0.28.0", features = ["fs", "socket"] }
 num-bigint-dig = "0.8.4"
 regex = { version = "1.10.0", default-features = false, features = ["std", "perf", "unicode-case"] }
+serde = { version = "1.0.203", features = ["derive"] }
+serde_cbor = "0.11"
 time = "0.3.34"
 walkdir = "2.5.0"
 zip = { version = "0.6.0", default-features = false, features = ["deflate", "deflate-zlib", "time"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ num-bigint-dig = "0.8.4"
 regex = { version = "1.10.0", default-features = false, features = ["std", "perf", "unicode-case"] }
 serde = { version = "1.0.203", features = ["derive"] }
 serde_cbor = "0.11"
+thiserror = "1.0.61"
 time = "0.3.34"
 walkdir = "2.5.0"
 zip = { version = "0.6.0", default-features = false, features = ["deflate", "deflate-zlib", "time"] }

--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ This option is intended to be used in rpm macros that define post-install steps.
 See [redhat-rpm-config pull request #293](https://src.fedoraproject.org/rpms/redhat-rpm-config/pull-request/293)
 for a pull request that added a call to `add-determinism` in `%__os_install_post`.
 
+### Verification instead of modification
+
+When invoked with `--check`, the tool processes all files,
+but does not actually save any modifications.
+Instead, it'll fail if any files would have been modified.
+It also returns an error if any files cannot be read.
+
 ## Processors
 
 ### `ar`
@@ -56,7 +63,7 @@ Resets the embedded modification times to `$SOURCE_DATE_EPOCH` and owner:group t
 
 Accepts `*.jar`.
 
-This rewrites the zip file using the `zip` create.
+This rewrites the zip file using the `zip` crate.
 The modification times of archive entries is clamped `$SOURCE_DATE_EPOCH`.
 Extra metadata, i.e. primarily timestamps in UNIX format and DOS permissions,
 are stripped (also because the crate does not support them).
@@ -75,8 +82,9 @@ and `<meta name="dc.created" content="<date>">` is replaced by a version with `$
 
 Accepts `*.pyc`.
 
-This handler implements a `.pyc` file parser and cleans up ununsed "flag references".
-It is a native reimplementation of
+This handler implements a `.pyc` file parser for Python bytecode files
+and cleans up unused "flag references".
+It is a Rust reimplementation of
 the [MarshalParser Python module](https://github.com/fedora-python/marshalparser).
 
 ## Notes
@@ -87,3 +95,5 @@ but is written from scratch in Rust.
 For Debian, build tools are written in Perl and more Perl is not an issue.
 But in Fedora/RHEL/…, tools are written in Bash, Python, or compiled,
 and we don't want to pull in Perl into all buildroots.
+In addition, the details differ in what kinds of processing we want to do.
+For example, Debian does not distribute Python bytecode files.

--- a/src/handlers/ar.rs
+++ b/src/handlers/ar.rs
@@ -156,7 +156,7 @@ mod tests {
 
     #[test]
     fn filter_a() {
-        let cfg = Rc::new(options::Config::empty(0));
+        let cfg = Rc::new(options::Config::empty(0, true));
         let h = Ar::boxed(&cfg);
 
         assert!( h.filter(Path::new("/some/path/libfoobar.a")).unwrap());

--- a/src/handlers/ar.rs
+++ b/src/handlers/ar.rs
@@ -44,7 +44,7 @@ impl super::Processor for Ar {
         Ok(path.extension().is_some_and(|x| x == "a"))
     }
 
-    fn process(&self, input_path: &Path) -> Result<bool> {
+    fn process(&self, input_path: &Path) -> Result<super::ProcessResult> {
         let mut have_mod = false;
         let (mut io, mut input) = InputOutputHelper::open(input_path)?;
 

--- a/src/handlers/ar.rs
+++ b/src/handlers/ar.rs
@@ -59,7 +59,7 @@ impl super::Processor for Ar {
 
     fn process(&self, input_path: &Path) -> Result<super::ProcessResult> {
         let mut have_mod = false;
-        let (mut io, mut input) = InputOutputHelper::open(input_path)?;
+        let (mut io, mut input) = InputOutputHelper::open(input_path, self.config.check)?;
 
         let mut buf = [0; MAGIC.len()];
         input.read_exact(&mut buf)?;

--- a/src/handlers/jar.rs
+++ b/src/handlers/jar.rs
@@ -32,7 +32,7 @@ impl super::Processor for Jar {
         Ok(path.extension().is_some_and(|x| x == "jar"))
     }
 
-    fn process(&self, input_path: &Path) -> Result<bool> {
+    fn process(&self, input_path: &Path) -> Result<super::ProcessResult> {
         let mut have_mod = false;
         let (mut io, input) = InputOutputHelper::open(input_path)?;
         let mut input = zip::ZipArchive::new(BufReader::new(input))?;

--- a/src/handlers/jar.rs
+++ b/src/handlers/jar.rs
@@ -35,7 +35,7 @@ impl super::Processor for Jar {
     fn process(&self, input_path: &Path) -> Result<super::ProcessResult> {
         let mut have_mod = false;
         let (mut io, input) = InputOutputHelper::open(input_path)?;
-        let mut input = zip::ZipArchive::new(BufReader::new(input))?;
+        let mut input = zip::ZipArchive::new(input)?;
 
         io.open_output()?;
 

--- a/src/handlers/jar.rs
+++ b/src/handlers/jar.rs
@@ -34,7 +34,7 @@ impl super::Processor for Jar {
 
     fn process(&self, input_path: &Path) -> Result<super::ProcessResult> {
         let mut have_mod = false;
-        let (mut io, input) = InputOutputHelper::open(input_path)?;
+        let (mut io, input) = InputOutputHelper::open(input_path, self.config.check)?;
         let mut input = zip::ZipArchive::new(input)?;
 
         io.open_output()?;

--- a/src/handlers/jar.rs
+++ b/src/handlers/jar.rs
@@ -55,8 +55,8 @@ impl super::Processor for Jar {
 
         if let Some(epoch) = epoch {
             match zip::DateTime::try_from(epoch) {
-                Err(err) => {
-                    warn!("Cannot convert epoch {} to zip::DateTime: {}", epoch, err);
+                Err(e) => {
+                    warn!("Cannot convert epoch {} to zip::DateTime: {}", epoch, e);
                 }
                 Ok(dos_epoch) => {
                     let ts: [u8; 4] = [

--- a/src/handlers/javadoc.rs
+++ b/src/handlers/javadoc.rs
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use log::{debug, info};
 use regex::{Regex, RegexBuilder};
 use std::io;
@@ -103,7 +103,7 @@ impl super::Processor for Javadoc {
                         info!("{}:{}: {}, ignoring.", input_path.display(), num + 1, e);
                         return Ok(super::ProcessResult::Noop);
                     } else {
-                        return Err(anyhow!("{}: failed to read line: {}", input_path.display(), e));
+                        return Err(e.into());
                     }
                 }
                 Ok(line) => line

--- a/src/handlers/javadoc.rs
+++ b/src/handlers/javadoc.rs
@@ -85,7 +85,7 @@ impl super::Processor for Javadoc {
         let mut have_mod = false;
         let mut after_header = false;
 
-        let (mut io, input) = InputOutputHelper::open(input_path)?;
+        let (mut io, input) = InputOutputHelper::open(input_path, self.config.check)?;
 
         io.open_output()?;
         let mut output = BufWriter::new(io.output.as_mut().unwrap());

--- a/src/handlers/javadoc.rs
+++ b/src/handlers/javadoc.rs
@@ -148,7 +148,7 @@ mod tests {
 
     #[test]
     fn test_filter_html() {
-        let cfg = Rc::new(options::Config::empty(1704106800));
+        let cfg = Rc::new(options::Config::empty(1704106800, false));
         let h = Javadoc::boxed(&cfg);
 
         assert!( h.filter(Path::new("/some/path/page.html")).unwrap());
@@ -162,7 +162,7 @@ mod tests {
 
     #[test]
     fn test_process_line() {
-        let config = Rc::new(options::Config::empty(1704106800));
+        let config = Rc::new(options::Config::empty(1704106800, false));
         let h = Javadoc { config };
         let plu = |s| h.process_line(s).unwrap();
 

--- a/src/handlers/javadoc.rs
+++ b/src/handlers/javadoc.rs
@@ -81,7 +81,7 @@ impl super::Processor for Javadoc {
         )
     }
 
-    fn process(&self, input_path: &Path) -> Result<bool> {
+    fn process(&self, input_path: &Path) -> Result<super::ProcessResult> {
         let mut have_mod = false;
         let mut after_header = false;
 
@@ -101,7 +101,7 @@ impl super::Processor for Javadoc {
                 Err(e) => {
                     if e.kind() == io::ErrorKind::InvalidData {
                         info!("{}:{}: {}, ignoring.", input_path.display(), num + 1, e);
-                        return Ok(false);
+                        return Ok(super::ProcessResult::Noop);
                     } else {
                         return Err(anyhow!("{}: failed to read line: {}", input_path.display(), e));
                     }
@@ -127,7 +127,7 @@ impl super::Processor for Javadoc {
                     };
 
                     debug!("{}:{}: found nothing to replace {}", input_path.display(), num, why);
-                    return Ok(false);
+                    return Ok(super::ProcessResult::Noop);
                 }
 
                 after_header = true;

--- a/src/handlers/javadoc.rs
+++ b/src/handlers/javadoc.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use log::{debug, info};
 use regex::{Regex, RegexBuilder};
 use std::io;
-use std::io::{BufRead, BufReader, BufWriter, Write};
+use std::io::{BufRead, BufWriter, Write};
 use std::path::Path;
 use std::rc::Rc;
 
@@ -86,7 +86,6 @@ impl super::Processor for Javadoc {
         let mut after_header = false;
 
         let (mut io, input) = InputOutputHelper::open(input_path)?;
-        let input = BufReader::new(input);
 
         io.open_output()?;
         let mut output = BufWriter::new(io.output.as_mut().unwrap());

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -89,7 +89,7 @@ pub trait Processor {
     fn process(&self, path: &Path) -> Result<ProcessResult>;
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct Stats {
     /// Count of directories that were scanned. This includes both
     /// command-line arguments and subdirectories found in recursive
@@ -122,17 +122,7 @@ pub struct Stats {
 }
 
 impl Stats {
-    pub fn new() -> Self {
-        Stats {
-            directories: 0,
-            files: 0,
-            inodes_processed: 0,
-            inodes_replaced: 0,
-            inodes_rewritten: 0,
-            misunderstood: 0,
-            errors: 0,
-        }
-    }
+    pub fn new() -> Self { Default::default() }
 
     pub fn add_one(&mut self, result: ProcessResult) {
         self.inodes_processed += 1;

--- a/src/handlers/pyc.rs
+++ b/src/handlers/pyc.rs
@@ -702,12 +702,12 @@ impl super::Processor for Pyc {
         Ok(path.extension().is_some_and(|x| x == "pyc"))
     }
 
-    fn process(&self, input_path: &Path) -> Result<bool> {
+    fn process(&self, input_path: &Path) -> Result<super::ProcessResult> {
         let (mut io, input) = InputOutputHelper::open(input_path)?;
 
         let mut parser = PycParser::from_file(input_path, input)?;
         if parser.version < (3, 0) {
-            return Ok(false);  // We don't want to touch python2 files
+            return Ok(super::ProcessResult::Noop);  // We don't want to touch python2 files
         }
 
         parser.read_object()?;

--- a/src/handlers/pyc.rs
+++ b/src/handlers/pyc.rs
@@ -737,7 +737,7 @@ mod tests {
 
     #[test]
     fn filter_a() {
-        let cfg = Rc::new(options::Config::empty(0));
+        let cfg = Rc::new(options::Config::empty(0, false));
         let h = Pyc::boxed(&cfg);
 
         assert!( h.filter(Path::new("/some/path/foobar.pyc")).unwrap());

--- a/src/handlers/pyc.rs
+++ b/src/handlers/pyc.rs
@@ -296,11 +296,13 @@ pub fn pyc_python_version(buf: &[u8; 4]) -> Result<((u32, u32), usize)> {
     }
 }
 
-pub struct Pyc {}
+pub struct Pyc {
+    config: Rc<options::Config>,
+}
 
 impl Pyc {
-    pub fn boxed(_config: &Rc<options::Config>) -> Box<dyn super::Processor> {
-        Box::new(Self {})
+    pub fn boxed(config: &Rc<options::Config>) -> Box<dyn super::Processor> {
+        Box::new(Self { config: config.clone() })
     }
 }
 
@@ -710,7 +712,7 @@ impl super::Processor for Pyc {
     }
 
     fn process(&self, input_path: &Path) -> Result<super::ProcessResult> {
-        let (mut io, input) = InputOutputHelper::open(input_path)?;
+        let (mut io, input) = InputOutputHelper::open(input_path, self.config.check)?;
 
         let mut parser = PycParser::from_file(input_path, input)?;
         if parser.version < (3, 0) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,5 +68,10 @@ fn main() -> Result<()> {
     }
 
     stats.summarize();
-    Ok(())
+
+    if stats.errors > 0 {
+        bail!("processing failed")
+    } else {
+        Ok(())
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ mod options;
 mod simplelog;
 
 use anyhow::{anyhow, bail, Result};
-use log::{debug, info};
+use log::debug;
 use std::env;
 use std::path::Path;
 
@@ -52,7 +52,7 @@ fn main() -> Result<()> {
 
     brp_check(&config)?;
 
-    let n_paths;
+    let stats;
 
     if let Some(socket) = config.socket {
         debug!("Running as worker on socket {}", socket);
@@ -60,13 +60,13 @@ fn main() -> Result<()> {
 
     } else if let Some(jobs) = config.jobs {
         debug!("Running as controller with {} workers", jobs);
-        n_paths = multiprocess::Controller::do_work(config)?;
+        stats = multiprocess::Controller::do_work(config)?;
 
     } else {
         // We're not the controller
-        n_paths = handlers::do_normal_work(config)?;
+        stats = handlers::do_normal_work(config)?;
     }
 
-    info!("Processed {} paths", n_paths);
+    stats.summarize();
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ use anyhow::{anyhow, bail, Result};
 use log::debug;
 use std::env;
 use std::path::Path;
+use std::rc::Rc;
 
 fn brp_check(config: &options::Config) -> Result<()> {
     // env::current_exe() does readlink("/proc/self/exe"), which returns
@@ -46,9 +47,10 @@ fn brp_check(config: &options::Config) -> Result<()> {
 
 fn main() -> Result<()> {
     let config = match options::Config::make()? {
-        None => { return Ok(()); },
+        None => { return Ok(()); }
         Some(some) => some
     };
+    let config = Rc::new(config);
 
     brp_check(&config)?;
 
@@ -56,22 +58,27 @@ fn main() -> Result<()> {
 
     if let Some(socket) = config.job_socket {
         debug!("Running as worker on job socket {}", socket);
-        return multiprocess::do_worker_work(config);
+        return multiprocess::do_worker_work(&config);
 
     } else if let Some(jobs) = config.jobs {
         debug!("Running as controller with {} workers", jobs);
-        stats = multiprocess::Controller::do_work(config)?;
+        stats = multiprocess::Controller::do_work(&config)?;
 
     } else {
         // We're not the controller
-        stats = handlers::do_normal_work(config)?;
+        stats = handlers::do_normal_work(&config)?;
     }
 
     stats.summarize();
 
     if stats.errors > 0 {
         bail!("processing failed")
-    } else {
+    } else if config.check && stats.misunderstood > 0 {
+        bail!("--check was specified some files couldn't be processed")
+    } else if config.check && (stats.inodes_replaced > 0 ||
+                               stats.inodes_rewritten > 0) {
+        bail!("--check was specified some files would have been modified")
+    }  else {
         Ok(())
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,8 +54,8 @@ fn main() -> Result<()> {
 
     let stats;
 
-    if let Some(socket) = config.socket {
-        debug!("Running as worker on socket {}", socket);
+    if let Some(socket) = config.job_socket {
+        debug!("Running as worker on job socket {}", socket);
         return multiprocess::do_worker_work(config);
 
     } else if let Some(jobs) = config.jobs {

--- a/src/multiprocess.rs
+++ b/src/multiprocess.rs
@@ -2,7 +2,7 @@
 
 use anyhow::{bail, Result};
 use log::{debug, warn};
-use nix::{fcntl, sys, unistd};
+use nix::{errno, fcntl, sys, unistd};
 use serde::{Serialize, Deserialize};
 use std::env;
 use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
@@ -18,7 +18,8 @@ use crate::options;
 
 pub struct Controller {
     handlers: Vec<Box<dyn handlers::Processor>>,
-    sockets: (OwnedFd, OwnedFd),
+    job_sockets: (OwnedFd, OwnedFd),
+    result_sockets: (OwnedFd, OwnedFd),
     workers: Vec<process::Child>,
 }
 
@@ -32,12 +33,14 @@ impl Controller {
     fn build_worker_command(
         config: &options::Config,
         handlers: &[Box<dyn handlers::Processor>],
-        fd: &RawFd,
+        job_fd: &RawFd,
+        result_fd: &RawFd,
     ) -> Result<process::Command> {
 
         let mut cmd = process::Command::new(env::current_exe()?);
 
-        cmd.arg("--socket").arg(fd.to_string());
+        cmd.arg("--job-socket").arg(job_fd.to_string());
+        cmd.arg("--result-socket").arg(result_fd.to_string());
         if config.brp {
             cmd.arg("--brp");
         }
@@ -61,17 +64,29 @@ impl Controller {
     pub fn create(config: &Rc<options::Config>) -> Result<Self> {
         let handlers = handlers::make_handlers(config)?;
 
-        let sockets = sys::socket::socketpair(
+        let job_sockets = sys::socket::socketpair(
+            sys::socket::AddressFamily::Unix,
+            sys::socket::SockType::Datagram,
+            None,
+            sys::socket::SockFlag::empty(),
+        )?;
+        let result_sockets = sys::socket::socketpair(
             sys::socket::AddressFamily::Unix,
             sys::socket::SockType::Datagram,
             None,
             sys::socket::SockFlag::empty(),
         )?;
 
-        fcntl::fcntl(sockets.1.as_raw_fd(), fcntl::F_SETFD(fcntl::FdFlag::FD_CLOEXEC))?;
+        fcntl::fcntl(job_sockets.1.as_raw_fd(), fcntl::F_SETFD(fcntl::FdFlag::FD_CLOEXEC))?;
+        fcntl::fcntl(result_sockets.1.as_raw_fd(), fcntl::F_SETFD(fcntl::FdFlag::FD_CLOEXEC))?;
+        fcntl::fcntl(result_sockets.1.as_raw_fd(), fcntl::F_SETFL(fcntl::OFlag::O_NONBLOCK))?;
 
-        let mut cmd = Self::build_worker_command(config, &handlers, &sockets.0.as_raw_fd())?;
-        // dbg!(&cmd);
+        let mut cmd = Self::build_worker_command(
+            config,
+            &handlers,
+            &job_sockets.0.as_raw_fd(),
+            &result_sockets.0.as_raw_fd(),
+        )?;
 
         let n = config.jobs.unwrap();
         let mut workers = vec![];
@@ -83,7 +98,8 @@ impl Controller {
 
         Ok(Controller {
             handlers,
-            sockets,
+            job_sockets,
+            result_sockets,
             workers,
         })
     }
@@ -100,7 +116,7 @@ impl Controller {
         let buf = serde_cbor::ser::to_vec_packed(&job)?;
 
         debug!("Sending {:?}", &job);
-        unistd::write(&self.sockets.1, &buf)?;
+        unistd::write(&self.job_sockets.1, &buf)?;
 
         Ok(())
     }
@@ -108,11 +124,11 @@ impl Controller {
     pub fn close(&mut self) -> Result<()> {
         debug!("Sending quit command to children…");
         for _ in &mut self.workers {
-            unistd::write(&self.sockets.1, b"")?;
+            unistd::write(&self.job_sockets.1, b"")?;
         }
 
         debug!("Closing control socket…");
-        unistd::close(self.sockets.1.as_raw_fd())?;
+        unistd::close(self.job_sockets.1.as_raw_fd())?;
 
         debug!("Waiting for children to exit…");
         for child in &mut self.workers {
@@ -128,6 +144,42 @@ impl Controller {
             }
         }
         debug!("Children are dead");
+        Ok(())
+    }
+
+    fn read_results(&mut self, total: &mut handlers::Stats) -> Result<()> {
+        debug!("Reading stats from children…");
+
+        let mut count = 0;
+        let mut buf = vec![0; 1024];
+
+        loop {
+            let n = match unistd::read(self.result_sockets.1.as_raw_fd(), &mut buf) {
+                Err(e) => {
+                    if e == errno::Errno::EAGAIN {
+                        break;
+                    } else {
+                        return Err(anyhow!("read failed: {}", e));
+                    }
+                }
+                Ok(n) => n,
+            };
+
+            if n == 0 {
+                break;
+            }
+
+            let stats = serde_cbor::de::from_mut_slice(&mut buf[..n])?;
+            debug!("Got result: {:?}", &stats);
+            total.add(&stats);
+
+            count += 1;
+        }
+
+        if count != self.workers.len() {
+            warn!("Got {} results from {} workers. (??)", count, self.workers.len());
+        }
+
         Ok(())
     }
 
@@ -156,22 +208,23 @@ impl Controller {
         }
 
         control.close()?;
+        control.read_results(&mut total)?;
         Ok(total)
     }
 }
 
-pub fn process_file_with_selected_handlers(
+fn process_file_with_selected_handlers(
     handlers: &[Box<dyn handlers::Processor>],
     selected_handlers: u8,
     input_path: &Path,
 ) -> Result<handlers::ProcessResult> {
 
-    let mut entry_mod = handlers::ProcessResult::Noop;
-
     // check if selected_handlers doesn't have any unexpected entries
     if u8::BITS - selected_handlers.leading_zeros() > handlers.len().try_into().unwrap() {
         bail!("Bad handler mask 0x{selected_handlers:x}");
     }
+
+    let mut entry_mod = handlers::ProcessResult::Noop;
 
     for (n_processor, processor) in handlers.iter().enumerate() {
         let cond = selected_handlers & (1 << n_processor) > 0;
@@ -187,16 +240,20 @@ pub fn process_file_with_selected_handlers(
 }
 
 pub fn do_worker_work(config: options::Config) -> Result<()> {
-    let socket = config.socket.unwrap();
-    let socket = unsafe { UnixDatagram::from_raw_fd(socket) };
+    let job_socket = config.job_socket.unwrap();
+    let job_socket = unsafe { UnixDatagram::from_raw_fd(job_socket) };
+
+    let result_socket = config.result_socket.unwrap();
+    let result_socket = unsafe { UnixDatagram::from_raw_fd(result_socket) };
 
     let config = Rc::new(config);
     let handlers = handlers::make_handlers(&config)?;
+    let mut stats = handlers::Stats::new();
 
     let mut buf = vec![0; 4096]; // FIXME: use a better limit here?
 
     loop {
-        let n = match socket.recv(buf.as_mut_slice()) {
+        let n = match job_socket.recv(buf.as_mut_slice()) {
             Err(e) => {
                 bail!("recv failed: {e}");
             }
@@ -204,17 +261,23 @@ pub fn do_worker_work(config: options::Config) -> Result<()> {
         };
 
         if n == 0 {
-            debug!("Worker {} says bye!", process::id());
-            return Ok(());
+            break;
         }
 
         let job: Job = serde_cbor::de::from_mut_slice(&mut buf[..n])?;
         debug!("Got job {:?}", job);
 
-        if let Err(e) =
-            process_file_with_selected_handlers(&handlers, job.selected_handlers, &job.input_path)
-        {
-            warn!("{}: failed to process: {}", job.input_path.display(), e);
-        }
+        let res = process_file_with_selected_handlers(
+            &handlers,
+            job.selected_handlers,
+            &job.input_path)?;
+        stats.add_one(job.selected_handlers, res);
     }
+
+    debug!("Worker {} wrapping up...", process::id());
+    let buf = serde_cbor::ser::to_vec_packed(&stats)?;
+    result_socket.send(&buf)?;
+
+    debug!("Worker {} says bye!", process::id());
+    Ok(())
 }

--- a/src/multiprocess.rs
+++ b/src/multiprocess.rs
@@ -47,6 +47,9 @@ impl Controller {
         if config.verbose {
             cmd.arg("-v");
         }
+        if config.check {
+            cmd.arg("--check");
+        }
         cmd.arg("--handler")
             .arg(handlers
                  .iter()
@@ -183,10 +186,8 @@ impl Controller {
         Ok(())
     }
 
-    pub fn do_work(config: options::Config) -> Result<handlers::Stats> {
-        let config = Rc::new(config);
-
-        let mut control = Controller::create(&config)?;
+    pub fn do_work(config: &Rc<options::Config>) -> Result<handlers::Stats> {
+        let mut control = Controller::create(config)?;
 
         let mut inodes_seen = handlers::inodes_seen();
         let mut total = handlers::Stats::new();
@@ -239,15 +240,14 @@ fn process_file_with_selected_handlers(
     Ok(entry_mod)
 }
 
-pub fn do_worker_work(config: options::Config) -> Result<()> {
+pub fn do_worker_work(config: &Rc<options::Config>) -> Result<()> {
     let job_socket = config.job_socket.unwrap();
     let job_socket = unsafe { UnixDatagram::from_raw_fd(job_socket) };
 
     let result_socket = config.result_socket.unwrap();
     let result_socket = unsafe { UnixDatagram::from_raw_fd(result_socket) };
 
-    let config = Rc::new(config);
-    let handlers = handlers::make_handlers(&config)?;
+    let handlers = handlers::make_handlers(config)?;
     let mut stats = handlers::Stats::new();
 
     let mut buf = vec![0; 4096]; // FIXME: use a better limit here?

--- a/src/options.rs
+++ b/src/options.rs
@@ -179,14 +179,14 @@ impl Config {
 
     #[allow(dead_code)]
     // FIXME: should this be marked as #[cfg(test)]? But then the tests don't compile.
-    pub const fn empty(source_date_epoch: i64) -> Self {
+    pub const fn empty(source_date_epoch: i64, check: bool) -> Self {
         Self {
             inputs: vec![],
             brp: false,
             verbose: false,
             job_socket: None,
             result_socket: None,
-            check: false,
+            check,
             jobs: None,
             source_date_epoch: Some(source_date_epoch),
             handler_names: vec![],

--- a/src/options.rs
+++ b/src/options.rs
@@ -31,6 +31,10 @@ struct Options {
     #[arg(short, long)]
     pub verbose: bool,
 
+    /// Fail if any modifications would have been made
+    #[arg(long)]
+    pub check: bool,
+
     /// Read paths to process from this socket.
     /// When used, an explicit list of handlers must be given.
     #[arg(long,
@@ -61,6 +65,7 @@ pub struct Config {
     pub verbose: bool,
     pub job_socket: Option<RawFd>,
     pub result_socket: Option<RawFd>,
+    pub check: bool,
     pub jobs: Option<u32>,
     pub source_date_epoch: Option<i64>,
     pub handler_names: Vec<&'static str>,
@@ -164,6 +169,7 @@ impl Config {
             verbose: options.verbose,
             job_socket: options.job_socket,
             result_socket: options.result_socket,
+            check: options.check,
             jobs: options.jobs,
             source_date_epoch,
             handler_names,
@@ -180,6 +186,7 @@ impl Config {
             verbose: false,
             job_socket: None,
             result_socket: None,
+            check: false,
             jobs: None,
             source_date_epoch: Some(source_date_epoch),
             handler_names: vec![],

--- a/src/options.rs
+++ b/src/options.rs
@@ -38,7 +38,14 @@ struct Options {
           conflicts_with = "inputs",
           conflicts_with = "jobs",
           requires = "handlers")]
-    pub socket: Option<RawFd>,
+    pub job_socket: Option<RawFd>,
+
+    /// Write results of processing to this socket.
+    /// When used, an explicit list of handlers must be given.
+    #[arg(long,
+          hide = true,
+          requires = "job_socket")]
+    pub result_socket: Option<RawFd>,
 
     /// Use N worker processes
     #[arg(short = 'j',
@@ -52,7 +59,8 @@ pub struct Config {
     pub inputs: Vec<PathBuf>,
     pub brp: bool,
     pub verbose: bool,
-    pub socket: Option<RawFd>,
+    pub job_socket: Option<RawFd>,
+    pub result_socket: Option<RawFd>,
     pub jobs: Option<u32>,
     pub source_date_epoch: Option<i64>,
     pub handler_names: Vec<&'static str>,
@@ -130,7 +138,7 @@ impl Config {
 
         // positional args
 
-        if options.socket.is_none() && options.inputs.is_empty() && !options.brp {
+        if options.job_socket.is_none() && options.inputs.is_empty() && !options.brp {
             info!("No arguments specified, nothing to do. 😎");
         }
 
@@ -154,7 +162,8 @@ impl Config {
             inputs: options.inputs,
             brp: options.brp,
             verbose: options.verbose,
-            socket: options.socket,
+            job_socket: options.job_socket,
+            result_socket: options.result_socket,
             jobs: options.jobs,
             source_date_epoch,
             handler_names,
@@ -169,7 +178,8 @@ impl Config {
             inputs: vec![],
             brp: false,
             verbose: false,
-            socket: None,
+            job_socket: None,
+            result_socket: None,
             jobs: None,
             source_date_epoch: Some(source_date_epoch),
             handler_names: vec![],

--- a/tests/test_handlers/mod.rs
+++ b/tests/test_handlers/mod.rs
@@ -76,6 +76,8 @@ fn stats(
         inodes_processed,
         inodes_replaced,
         inodes_rewritten,
+        misunderstood: 0,
+        errors: 0,
     }
 }
 

--- a/tests/test_handlers/mod.rs
+++ b/tests/test_handlers/mod.rs
@@ -21,10 +21,11 @@ fn prepare_dir(path: &str) -> Result<(Box<TempDir>, Box<PathBuf>)> {
 
 fn make_handler(
     source_date_epoch: i64,
+    check: bool,
     func: handlers::HandlerBoxed,
 ) -> Result<Box<dyn handlers::Processor>> {
 
-    let cfg = Rc::new(options::Config::empty(source_date_epoch));
+    let cfg = Rc::new(options::Config::empty(source_date_epoch, check));
     let mut handler = func(&cfg);
     handler.initialize()?;
     Ok(handler)
@@ -111,7 +112,7 @@ fn test_inode_map() {
 fn test_inode_map_2() {
     let (dir, _input) = prepare_dir("tests/cases/testrelro.a").unwrap();
 
-    let cfg = Rc::new(options::Config::empty(111));
+    let cfg = Rc::new(options::Config::empty(111, false));
     let ar = handlers::ar::Ar::boxed(&cfg);
 
     let handlers = vec![ar];

--- a/tests/test_handlers/mod.rs
+++ b/tests/test_handlers/mod.rs
@@ -55,7 +55,7 @@ impl handlers::Processor for Trivial {
 fn test_input_output_helper_drop() {
     let (_dir, input) = prepare_dir("tests/cases/libempty.a").unwrap();
 
-    let (mut helper, _) = handlers::InputOutputHelper::open(&*input).unwrap();
+    let (mut helper, _) = handlers::InputOutputHelper::open(&*input, false).unwrap();
     helper.open_output().unwrap();
 
     let output_path = helper.output_path.as_ref().unwrap().clone();

--- a/tests/test_handlers/test_ar.rs
+++ b/tests/test_handlers/test_ar.rs
@@ -5,6 +5,7 @@ use std::os::linux::fs::MetadataExt;
 use std::rc::Rc;
 
 use add_determinism::options;
+use add_determinism::handlers;
 use add_determinism::handlers::ar;
 
 use super::{prepare_dir, make_handler, test_corpus_file};
@@ -19,7 +20,7 @@ fn test_libempty() {
 
     let orig = input.metadata().unwrap();
 
-    assert_eq!(ar.process(&*input).unwrap(), false);
+    assert_eq!(ar.process(&*input).unwrap(), handlers::ProcessResult::Noop);
 
     let new = input.metadata().unwrap();
     assert_eq!(orig.created().unwrap(), new.created().unwrap());
@@ -38,7 +39,7 @@ fn test_testrelro() {
 
     let orig = input.metadata().unwrap();
 
-    assert_eq!(ar.process(&*input).unwrap(), true);
+    assert_eq!(ar.process(&*input).unwrap(), handlers::ProcessResult::Replaced);
 
     let new = input.metadata().unwrap();
     // because of timestamp granularity, creation ts might be equal
@@ -59,7 +60,7 @@ fn test_testrelro_hardlinked() {
 
     fs::hard_link(&*input, (*input).with_extension("b")).unwrap();
 
-    assert_eq!(ar.process(&*input).unwrap(), true);
+    assert_eq!(ar.process(&*input).unwrap(), handlers::ProcessResult::Rewritten);
 
     let new = input.metadata().unwrap();
     assert_eq!(orig.created().unwrap(), new.created().unwrap());
@@ -95,7 +96,7 @@ fn test_testrelro_fixed() {
 
     let orig = input.metadata().unwrap();
 
-    assert_eq!(ar.process(&*input).unwrap(), false);
+    assert_eq!(ar.process(&*input).unwrap(), handlers::ProcessResult::Noop);
 
     let new = input.metadata().unwrap();
     assert_eq!(orig.created().unwrap(), new.created().unwrap());

--- a/tests/test_handlers/test_ar.rs
+++ b/tests/test_handlers/test_ar.rs
@@ -14,7 +14,7 @@ use super::{prepare_dir, make_handler, test_corpus_file};
 fn test_libempty() {
     let (_dir, input) = prepare_dir("tests/cases/libempty.a").unwrap();
 
-    let ar = make_handler(111, ar::Ar::boxed).unwrap();
+    let ar = make_handler(111, false, ar::Ar::boxed).unwrap();
 
     assert!(ar.filter(&*input).unwrap());
 
@@ -32,7 +32,7 @@ fn test_libempty() {
 fn test_testrelro() {
     let (_dir, input) = prepare_dir("tests/cases/testrelro.a").unwrap();
 
-    let cfg = Rc::new(options::Config::empty(111));
+    let cfg = Rc::new(options::Config::empty(111, false));
     let ar = ar::Ar::boxed(&cfg);
 
     assert!(ar.filter(&*input).unwrap());
@@ -52,7 +52,7 @@ fn test_testrelro() {
 fn test_testrelro_hardlinked() {
     let (_dir, input) = prepare_dir("tests/cases/testrelro.a").unwrap();
 
-    let ar = make_handler(111, ar::Ar::boxed).unwrap();
+    let ar = make_handler(111, false, ar::Ar::boxed).unwrap();
 
     assert!(ar.filter(&*input).unwrap());
 
@@ -72,7 +72,7 @@ fn test_testrelro_hardlinked() {
 fn test_testrelro_c() {
     let (_dir, input) = prepare_dir("tests/cases/testrelro.c").unwrap();
 
-    let ar = make_handler(111, ar::Ar::boxed).unwrap();
+    let ar = make_handler(111, false, ar::Ar::boxed).unwrap();
 
     assert!(!ar.filter(&*input).unwrap());
 
@@ -90,7 +90,7 @@ fn test_testrelro_c() {
 fn test_testrelro_fixed() {
     let (_dir, input) = prepare_dir("tests/cases/testrelro.fixed.a").unwrap();
 
-    let ar = make_handler(111, ar::Ar::boxed).unwrap();
+    let ar = make_handler(111, false, ar::Ar::boxed).unwrap();
 
     assert!(ar.filter(&*input).unwrap());
 
@@ -112,6 +112,6 @@ fn test_libhsbase_compat_batteries() {
 
     let filename = "tests/cases/libHSbase-compat-batteries-0.12.3-EvvecFThiaEAGWq5U5Tpi9.a";
 
-    let ar = make_handler(1717842014, ar::Ar::boxed).unwrap();
+    let ar = make_handler(1717842014, false, ar::Ar::boxed).unwrap();
     test_corpus_file(ar, filename);
 }

--- a/tests/test_handlers/test_javadoc.rs
+++ b/tests/test_handlers/test_javadoc.rs
@@ -12,7 +12,7 @@ use super::{prepare_dir, make_handler};
 fn test_javadoc_example() {
     let (_dir, input) = prepare_dir("tests/cases/javadoc-example.html").unwrap();
 
-    let javadoc = make_handler(1704106800, javadoc::Javadoc::boxed).unwrap();
+    let javadoc = make_handler(1704106800, false, javadoc::Javadoc::boxed).unwrap();
 
     assert!(javadoc.filter(&*input).unwrap());
 
@@ -34,7 +34,7 @@ fn test_javadoc_example() {
 fn test_javadoc_fixed() {
     let (_dir, input) = prepare_dir("tests/cases/javadoc-example.fixed.html").unwrap();
 
-    let javadoc = make_handler(1704106800, javadoc::Javadoc::boxed).unwrap();
+    let javadoc = make_handler(1704106800, false, javadoc::Javadoc::boxed).unwrap();
 
     assert!(javadoc.filter(&*input).unwrap());
 
@@ -52,7 +52,7 @@ fn test_javadoc_fixed() {
 fn test_invalid_utf8() {
     let (_dir, input) = prepare_dir("tests/cases/invalid-utf8.html").unwrap();
 
-    let javadoc = make_handler(1704106800, javadoc::Javadoc::boxed).unwrap();
+    let javadoc = make_handler(1704106800, false, javadoc::Javadoc::boxed).unwrap();
 
     assert!(javadoc.filter(&*input).unwrap());
 

--- a/tests/test_handlers/test_javadoc.rs
+++ b/tests/test_handlers/test_javadoc.rs
@@ -3,6 +3,7 @@
 use std::fs;
 use std::os::linux::fs::MetadataExt;
 
+use add_determinism::handlers;
 use add_determinism::handlers::javadoc;
 
 use super::{prepare_dir, make_handler};
@@ -17,7 +18,7 @@ fn test_javadoc_example() {
 
     let orig = input.metadata().unwrap();
 
-    assert_eq!(javadoc.process(&*input).unwrap(), true);
+    assert_eq!(javadoc.process(&*input).unwrap(), handlers::ProcessResult::Replaced);
 
     let new = input.metadata().unwrap();
     // because of timestamp granularity, creation ts might be equal
@@ -39,7 +40,7 @@ fn test_javadoc_fixed() {
 
     let orig = input.metadata().unwrap();
 
-    assert_eq!(javadoc.process(&*input).unwrap(), false);
+    assert_eq!(javadoc.process(&*input).unwrap(), handlers::ProcessResult::Noop);
 
     let new = input.metadata().unwrap();
     assert_eq!(orig.created().unwrap(), new.created().unwrap());
@@ -57,7 +58,7 @@ fn test_invalid_utf8() {
 
     let orig = input.metadata().unwrap();
 
-    assert_eq!(javadoc.process(&*input).unwrap(), false);
+    assert_eq!(javadoc.process(&*input).unwrap(), handlers::ProcessResult::Noop);
 
     let new = input.metadata().unwrap();
     assert_eq!(orig.created().unwrap(), new.created().unwrap());

--- a/tests/test_handlers/test_pyc.rs
+++ b/tests/test_handlers/test_pyc.rs
@@ -28,7 +28,7 @@ fn test_pyc_python_version() {
 fn test_adapters() {
     let (_dir, input) = prepare_dir("tests/cases/adapters.cpython-312.pyc").unwrap();
 
-    let pyc = make_handler(111, pyc::Pyc::boxed).unwrap();
+    let pyc = make_handler(111, false, pyc::Pyc::boxed).unwrap();
 
     assert!(pyc.filter(&*input).unwrap());
 
@@ -47,7 +47,7 @@ fn test_adapters() {
 fn test_adapters_hardlinked() {
     let (_dir, input) = prepare_dir("tests/cases/adapters.cpython-312.pyc").unwrap();
 
-    let pyc = make_handler(111, pyc::Pyc::boxed).unwrap();
+    let pyc = make_handler(111, false, pyc::Pyc::boxed).unwrap();
 
     assert!(pyc.filter(&*input).unwrap());
 
@@ -67,7 +67,7 @@ fn test_adapters_hardlinked() {
 fn test_adapters_opt_1() {
     let (_dir, input) = prepare_dir("tests/cases/adapters.cpython-312.opt-1.pyc").unwrap();
 
-    let pyc = make_handler(111, pyc::Pyc::boxed).unwrap();
+    let pyc = make_handler(111, false, pyc::Pyc::boxed).unwrap();
 
     assert!(pyc.filter(&*input).unwrap());
 
@@ -87,7 +87,7 @@ fn test_adapters_opt_1() {
 fn test_testrelro_fixed() {
     let (_dir, input) = prepare_dir("tests/cases/adapters.cpython-312~fixed.pyc").unwrap();
 
-    let pyc = make_handler(111, pyc::Pyc::boxed).unwrap();
+    let pyc = make_handler(111, false, pyc::Pyc::boxed).unwrap();
 
     assert!(pyc.filter(&*input).unwrap());
 
@@ -108,7 +108,7 @@ fn test_python_stdlib_file_1() {
 }
 
 fn test_python_stdlib_file(filename: &str) {
-    let pyc = make_handler(1717842014, pyc::Pyc::boxed).unwrap();
+    let pyc = make_handler(1717842014, false, pyc::Pyc::boxed).unwrap();
     test_corpus_file(pyc, filename);
 }
 

--- a/tests/test_handlers/test_pyc.rs
+++ b/tests/test_handlers/test_pyc.rs
@@ -5,6 +5,7 @@ use std::fs::File;
 use std::os::linux::fs::MetadataExt;
 use std::path::Path;
 
+use add_determinism::handlers;
 use add_determinism::handlers::pyc;
 
 use super::{prepare_dir, make_handler, test_corpus_file};
@@ -33,7 +34,7 @@ fn test_adapters() {
 
     let orig = input.metadata().unwrap();
 
-    assert_eq!(pyc.process(&*input).unwrap(), true);
+    assert_eq!(pyc.process(&*input).unwrap(), handlers::ProcessResult::Replaced);
 
     let new = input.metadata().unwrap();
     // because of timestamp granularity, creation ts might be equal
@@ -54,7 +55,7 @@ fn test_adapters_hardlinked() {
 
     fs::hard_link(&*input, (*input).with_extension("pyc.evenbetter")).unwrap();
 
-    assert_eq!(pyc.process(&*input).unwrap(), true);
+    assert_eq!(pyc.process(&*input).unwrap(), handlers::ProcessResult::Rewritten);
 
     let new = input.metadata().unwrap();
     assert_eq!(orig.created().unwrap(), new.created().unwrap());
@@ -72,7 +73,7 @@ fn test_adapters_opt_1() {
 
     let orig = input.metadata().unwrap();
 
-    assert_eq!(pyc.process(&*input).unwrap(), true);
+    assert_eq!(pyc.process(&*input).unwrap(), handlers::ProcessResult::Replaced);
 
     let new = input.metadata().unwrap();
     // because of timestamp granularity, creation ts might be equal
@@ -92,7 +93,7 @@ fn test_testrelro_fixed() {
 
     let orig = input.metadata().unwrap();
 
-    assert_eq!(pyc.process(&*input).unwrap(), false);
+    assert_eq!(pyc.process(&*input).unwrap(), handlers::ProcessResult::Noop);
 
     let new = input.metadata().unwrap();
     assert_eq!(orig.created().unwrap(), new.created().unwrap());


### PR DESCRIPTION
This seems to be a good initial implementation. We gather statistics of what was done and print them out. If `--check` is specified, we skip the step where the original file is replaced by the modified version.

This could be integrated in an rpm build in two ways:
- use `%global add_determinism_options --check` to hook into the default postinstall phase
- call `add-determinism --check` explicitly during build, possibly only on some subset of `%buildroot`.