### PR TITLE
Remove duplicate and incomplete handling of errors

### DIFF
--- a/src/multiprocess.rs
+++ b/src/multiprocess.rs
@@ -193,19 +193,12 @@ impl Controller {
         let mut total = handlers::Stats::new();
 
         for input_path in &config.inputs {
-            match handlers::process_file_or_dir(
+            let stats = handlers::process_file_or_dir(
                 &control.handlers,
                 &mut inodes_seen,
                 input_path,
-                Some(&|selected_handlers, input_path| control.send_job(selected_handlers, input_path)))
-            {
-                Err(err) => {
-                    warn!("{}: failed to process: {}", input_path.display(), err);
-                }
-                Ok(stats) => {
-                    total.add(&stats);
-                }
-            };
+                Some(&|selected_handlers, input_path| control.send_job(selected_handlers, input_path)));
+            total.add(&stats);
         }
 
         control.close()?;

--- a/tests/test_handlers/mod.rs
+++ b/tests/test_handlers/mod.rs
@@ -90,20 +90,20 @@ fn test_inode_map() {
     let mut handlers = vec![ Trivial::boxed() ];
     let mut cache = handlers::inodes_seen();
 
-    let mods = handlers::process_file_or_dir(&handlers, &mut cache, dir.path(), None).unwrap();
+    let mods = handlers::process_file_or_dir(&handlers, &mut cache, dir.path(), None);
     assert_eq!(mods, stats(1, 1, 0));
 
-    let mods = handlers::process_file_or_dir(&handlers, &mut cache, dir.path(), None).unwrap();
+    let mods = handlers::process_file_or_dir(&handlers, &mut cache, dir.path(), None);
     assert_eq!(mods, stats(0, 0, 0));
 
     assert_eq!(cache.len(), 1);
 
     handlers.push(Trivial::boxed());
 
-    let mods = handlers::process_file_or_dir(&handlers, &mut cache, dir.path(), None).unwrap();
+    let mods = handlers::process_file_or_dir(&handlers, &mut cache, dir.path(), None);
     assert_eq!(mods, stats(1, 1, 0));
 
-    let mods = handlers::process_file_or_dir(&handlers, &mut cache, dir.path(), None).unwrap();
+    let mods = handlers::process_file_or_dir(&handlers, &mut cache, dir.path(), None);
     assert_eq!(mods, stats(0, 0, 0));
 
     assert_eq!(cache.len(), 1);
@@ -119,10 +119,10 @@ fn test_inode_map_2() {
     let handlers = vec![ar];
     let mut cache = handlers::inodes_seen();
 
-    let mods = handlers::process_file_or_dir(&handlers, &mut cache, dir.path(), None).unwrap();
+    let mods = handlers::process_file_or_dir(&handlers, &mut cache, dir.path(), None);
     assert_eq!(mods, stats(1, 1, 0));
 
-    let mods = handlers::process_file_or_dir(&handlers, &mut cache, dir.path(), None).unwrap();
+    let mods = handlers::process_file_or_dir(&handlers, &mut cache, dir.path(), None);
     // The file was already processed, so no change
     assert_eq!(mods, stats(0, 0, 0));
 


### PR DESCRIPTION
When invoked as 'add-determinism /nonexistent/path', we'd get a very verbose error and a non-zero exit code. But when invoked as 'add-determinism -j2 /nonexistent/path', we'd get just warning message and zero exit code. The initial idea was that a non-existent path arg would be a fatal error, but errors in nested files would just result in a warning. But since the introduction of the full stats, this old model doesn't make much sense. Let's treat errors uniformly: if we fail to process a path, warn and continue, and always exit non-zero if any errors were recorded.