### PR TITLE
feat: fix MetadataExt imports for macOS builds

### DIFF
--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -15,12 +15,16 @@ use std::ffi::OsStr;
 use std::fs;
 use std::fs::{File, Metadata};
 use std::io::{self, Seek};
-use std::os::linux::fs::MetadataExt as _;
 use std::os::unix::fs as unix_fs;
 use std::os::unix::fs::MetadataExt as _;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
 use thiserror::Error;
+
+#[cfg(target_os = "linux")]
+use std::os::linux::fs::MetadataExt as _;
+#[cfg(target_os = "macos")]
+use std::os::macos::fs::MetadataExt as _;
 
 use crate::config;
 

--- a/src/multiprocess.rs
+++ b/src/multiprocess.rs
@@ -76,6 +76,7 @@ impl Controller {
             sndbuf = sys::socket::getsockopt(fd, sys::socket::sockopt::SndBuf)?;
             debug!("Tried to set socket buffer size to {}, got {}", newsize, sndbuf);
 
+            #[cfg(any(target_os = "android", target_os = "linux"))]
             if newsize > sndbuf {
                 if let Err(err) = sys::socket::setsockopt(
                     fd,

--- a/tests/test_handlers/test_ar.rs
+++ b/tests/test_handlers/test_ar.rs
@@ -1,8 +1,11 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 
 use std::fs;
-use std::os::linux::fs::MetadataExt;
 use std::rc::Rc;
+#[cfg(target_os = "linux")]
+use std::os::linux::fs::MetadataExt as _;
+#[cfg(target_os = "macos")]
+use std::os::macos::fs::MetadataExt as _;
 
 use add_determinism::config;
 use add_determinism::handlers;

--- a/tests/test_handlers/test_javadoc.rs
+++ b/tests/test_handlers/test_javadoc.rs
@@ -1,7 +1,10 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 
 use std::fs;
-use std::os::linux::fs::MetadataExt;
+#[cfg(target_os = "linux")]
+use std::os::linux::fs::MetadataExt as _;
+#[cfg(target_os = "macos")]
+use std::os::macos::fs::MetadataExt as _;
 
 use add_determinism::handlers;
 use add_determinism::handlers::javadoc;

--- a/tests/test_handlers/test_pyc.rs
+++ b/tests/test_handlers/test_pyc.rs
@@ -3,8 +3,11 @@
 use std::io::Read;
 use std::fs;
 use std::fs::File;
-use std::os::linux::fs::MetadataExt;
 use std::path::Path;
+#[cfg(target_os = "linux")]
+use std::os::linux::fs::MetadataExt as _;
+#[cfg(target_os = "macos")]
+use std::os::macos::fs::MetadataExt as _;
 
 use add_determinism::handlers;
 use add_determinism::handlers::pyc;

--- a/tests/test_handlers/test_pyc_zero_mtime.rs
+++ b/tests/test_handlers/test_pyc_zero_mtime.rs
@@ -1,8 +1,11 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 
 use std::fs;
-use std::os::linux::fs::MetadataExt;
 use std::time;
+#[cfg(target_os = "linux")]
+use std::os::linux::fs::MetadataExt as _;
+#[cfg(target_os = "macos")]
+use std::os::macos::fs::MetadataExt as _;
 
 use add_determinism::handlers;
 use add_determinism::handlers::pyc;


### PR DESCRIPTION
This commit updates the add-determinism codebase to use the appropriate platform-specific `MetadataExt` trait for file metadata operations. Specifically:

1. In the `handlers/mod.rs` file, the `MetadataExt` import is now conditional on the target operating system, using `std::os::linux::fs::MetadataExt` for Linux and `std::os::macos::fs::MetadataExt` for macOS.

2. Similar changes were made in the test files (`test_ar.rs`, `test_javadoc.rs`, `test_pyc.rs`, and `test_pyc_zero_mtime.rs`) to ensure the correct `MetadataExt` trait is used based on the target platform.