### PR TITLE
Revert "pyc: make sure we don't try to process files with hash invalidation"

### DIFF
--- a/src/handlers/pyc.rs
+++ b/src/handlers/pyc.rs
@@ -1736,11 +1736,6 @@ impl super::Processor for Pyc {
         if parser.version < (3, 0) {
             return Ok(super::ProcessResult::Noop);  // We don't want to touch python2 files
         }
-        if parser.py_content_hash().is_some() {
-            return Err(super::Error::Other(
-                "pyc file with hash invalidation are not supported".to_string()
-            ).into());
-        }
 
         let code = parser.read_object()?;
 


### PR DESCRIPTION
This reverts commit 77786360c83b447c41ba2a1af470cb5a041c5128.

Actually, this should work fine. The hash is for the .py file contents, not for the .pyc file. So we can rewrite the .pyc file, we just need to preserve the hash that stored in the header.