### PR TITLE
multiprocess: fix usize→u32 casting

### DIFF
--- a/src/multiprocess.rs
+++ b/src/multiprocess.rs
@@ -256,7 +256,7 @@ fn process_file_with_selected_handlers(
 ) -> Result<handlers::ProcessResult> {
 
     // check if selected_handlers doesn't have any unexpected entries
-    if u8::BITS - selected_handlers.leading_zeros() > handlers.len().try_into().unwrap() {
+    if u8::BITS - selected_handlers.leading_zeros() > handlers.len() as u32 {
         bail!("Bad handler mask 0x{selected_handlers:x}");
     }
 


### PR DESCRIPTION
This started to fail in CI:
error[E0283]: type annotations needed
   --> src/multiprocess.rs:258:70
    |
258 |     if u8::BITS - selected_handlers.leading_zeros() > handlers.len().try_into().unwrap() {
    |                                                     -                ^^^^^^^^
    |                                                     |
    |                                                     type must be known at this point
I'm not sure why it stopped being acceptable and why it doesn't fail
here, even though I have the same cargo version 1.85.1 as in the CI.

Anyway, 'as' should do the job.