### PR TITLE
Change process-based parallelism to thread-based paralellism

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -165,6 +165,7 @@ exclude = [
 anyhow = "1.0.12"
 chrono = "0.4.35"
 clap = { version = "4.4.18", features = ["derive"] }
+crossbeam-channel = "0.5.15"
 indoc = "2.0.4"
 itertools = "0.13.0"
 log = { version = "0.4", features = ["std"] }
@@ -173,8 +174,7 @@ num-bigint-dig = "0.8.4"
 num-integer = "0.1.46"
 num-traits = "0.2.19"
 regex = { version = "1.10.0", default-features = false, features = ["std", "perf", "unicode-case"] }
-serde = { version = "1.0.203", features = ["derive"] }
-serde_cbor = "0.11"
+rlimit = "0.10.2"
 tempfile = "3.20"
 thiserror = "1.0.61"
 time = "0.3.34"

--- a/src/handlers/ar.rs
+++ b/src/handlers/ar.rs
@@ -5,7 +5,7 @@ use log::debug;
 use std::fs::File;
 use std::io::{BufReader, BufWriter, Read, Seek, Write, ErrorKind};
 use std::path::Path;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use crate::handlers::InputOutputHelper;
 use crate::config;
@@ -16,11 +16,11 @@ const FILE_HEADER_LENGTH: usize = 60;
 const FILE_HEADER_MAGIC: &[u8] = &[0o140, 0o012];
 
 pub struct Ar {
-    config: Rc<config::Config>,
+    config: Arc<config::Config>,
 }
 
 impl Ar {
-    pub fn boxed(config: &Rc<config::Config>) -> Box<dyn super::Processor> {
+    pub fn boxed(config: &Arc<config::Config>) -> Box<dyn super::Processor + Send + Sync> {
         Box::new(Self { config: config.clone() })
     }
 }
@@ -156,7 +156,7 @@ mod tests {
 
     #[test]
     fn filter_a() {
-        let cfg = Rc::new(config::Config::empty(0, true));
+        let cfg = Arc::new(config::Config::empty(0, true));
         let h = Ar::boxed(&cfg);
 
         assert!( h.filter(Path::new("/some/path/libfoobar.a")).unwrap());

--- a/src/handlers/gzip.rs
+++ b/src/handlers/gzip.rs
@@ -5,7 +5,7 @@ use log::{debug, info};
 use std::io;
 use std::io::{BufWriter, Read, Write};
 use std::path::Path;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use crate::handlers::InputOutputHelper;
 use crate::config;
@@ -15,12 +15,12 @@ const GZIP_MAGIC: &[u8] = &[0x1F, 0x8B];
 // Based on https://www.ietf.org/rfc/rfc1952.txt.
 
 pub struct Gzip {
-    config: Rc<config::Config>,
+    config: Arc<config::Config>,
     unix_epoch: Option<u32>,
 }
 
 impl Gzip {
-    pub fn boxed(config: &Rc<config::Config>) -> Box<dyn super::Processor> {
+    pub fn boxed(config: &Arc<config::Config>) -> Box<dyn super::Processor + Send + Sync> {
         Box::new(Self {
             config: config.clone(),
             unix_epoch: None,
@@ -97,7 +97,7 @@ mod tests {
 
     #[test]
     fn test_filter_html() {
-        let cfg = Rc::new(config::Config::empty(1704106800, false));
+        let cfg = Arc::new(config::Config::empty(1704106800, false));
         let h = Gzip::boxed(&cfg);
 
         assert!( h.filter(Path::new("/some/path/page.gz")).unwrap());

--- a/src/handlers/javadoc.rs
+++ b/src/handlers/javadoc.rs
@@ -6,7 +6,7 @@ use regex::{Regex, RegexBuilder};
 use std::io;
 use std::io::{BufRead, BufWriter, Write};
 use std::path::Path;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use crate::handlers::InputOutputHelper;
 use crate::config;
@@ -14,11 +14,11 @@ use crate::config;
 const HEADER_LINES_TO_CHECK: i32 = 15;
 
 pub struct Javadoc {
-    config: Rc<config::Config>,
+    config: Arc<config::Config>,
 }
 
 impl Javadoc {
-    pub fn boxed(config: &Rc<config::Config>) -> Box<dyn super::Processor> {
+    pub fn boxed(config: &Arc<config::Config>) -> Box<dyn super::Processor + Send + Sync> {
         Box::new(Self { config: config.clone() })
     }
 
@@ -150,7 +150,7 @@ mod tests {
 
     #[test]
     fn test_filter_html() {
-        let cfg = Rc::new(config::Config::empty(1704106800, false));
+        let cfg = Arc::new(config::Config::empty(1704106800, false));
         let h = Javadoc::boxed(&cfg);
 
         assert!( h.filter(Path::new("/some/path/page.html")).unwrap());
@@ -164,7 +164,7 @@ mod tests {
 
     #[test]
     fn test_process_line() {
-        let config = Rc::new(config::Config::empty(1704106800, false));
+        let config = Arc::new(config::Config::empty(1704106800, false));
         let h = Javadoc { config };
         let plu = |s| h.process_line(s).unwrap();
 

--- a/src/handlers/pyc.rs
+++ b/src/handlers/pyc.rs
@@ -19,6 +19,7 @@ use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
 use std::str;
+use std::sync::Arc;
 use std::time;
 
 use num_bigint_dig::{BigInt, ToBigInt};
@@ -1717,15 +1718,15 @@ impl PycWriter {
 
 
 pub struct Pyc {
-    config: Rc<config::Config>,
+    config: Arc<config::Config>,
 }
 
 impl Pyc {
-    pub fn new(config: &Rc<config::Config>) -> Self {
+    pub fn new(config: &Arc<config::Config>) -> Self {
         Self { config: config.clone() }
     }
 
-    pub fn boxed(config: &Rc<config::Config>) -> Box<dyn super::Processor> {
+    pub fn boxed(config: &Arc<config::Config>) -> Box<dyn super::Processor + Send + Sync> {
         Box::new(Self::new(config))
     }
 }
@@ -1784,11 +1785,11 @@ impl Pyc {
 }
 
 pub struct PycZeroMtime {
-    config: Rc<config::Config>,
+    config: Arc<config::Config>,
 }
 
 impl PycZeroMtime {
-    pub fn boxed(config: &Rc<config::Config>) -> Box<dyn super::Processor> {
+    pub fn boxed(config: &Arc<config::Config>) -> Box<dyn super::Processor + Send + Sync> {
         Box::new(Self { config: config.clone() })
     }
 

--- a/src/handlers/zip.rs
+++ b/src/handlers/zip.rs
@@ -5,7 +5,7 @@ use log::{debug, warn};
 use std::fs::File;
 use std::io::{BufReader, BufWriter, Read, Seek, SeekFrom, Write};
 use std::path::Path;
-use std::rc::Rc;
+use std::sync::Arc;
 use time;
 
 use crate::handlers::InputOutputHelper;
@@ -19,13 +19,15 @@ pub struct Zip {
     // separate handlers which can be enabled independently.
     extension: &'static str,
 
-    config: Rc<config::Config>,
+    config: Arc<config::Config>,
     unix_epoch: Option<time::OffsetDateTime>,
     dos_epoch: Option<zip::DateTime>,
 }
 
 impl Zip {
-    fn boxed(config: &Rc<config::Config>, extension: &'static str) -> Box<dyn super::Processor> {
+    fn boxed(config: &Arc<config::Config>, extension: &'static str)
+             -> Box<dyn super::Processor + Send + Sync>
+    {
         Box::new(Self {
             extension,
             config: config.clone(),
@@ -34,11 +36,11 @@ impl Zip {
         })
     }
 
-    pub fn boxed_zip(config: &Rc<config::Config>) -> Box<dyn super::Processor> {
+    pub fn boxed_zip(config: &Arc<config::Config>) -> Box<dyn super::Processor + Send + Sync> {
         Self::boxed(config, "zip")
     }
 
-    pub fn boxed_jar(config: &Rc<config::Config>) -> Box<dyn super::Processor> {
+    pub fn boxed_jar(config: &Arc<config::Config>) -> Box<dyn super::Processor + Send + Sync> {
         Self::boxed(config, "jar")
     }
 }

--- a/src/multiprocess.rs
+++ b/src/multiprocess.rs
@@ -1,150 +1,66 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 
 use anyhow::{bail, Result};
-use log::{debug, info, warn, error};
-use nix::{errno, fcntl, sys, unistd};
-use serde::{Serialize, Deserialize};
-use std::{cmp, env, process, str};
-use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
-use std::os::unix::net::UnixDatagram;
-use std::os::unix::process::ExitStatusExt;
+use log::debug;
+use std::thread;
 use std::path::{Path, PathBuf};
-use std::rc::Rc;
+use std::sync::Arc;
+use crossbeam_channel::{Sender,Receiver};
 
 use crate::config;
 use crate::handlers;
 
 pub struct Controller {
-    handlers: Vec<Box<dyn handlers::Processor>>,
-    job_sockets: Option<(OwnedFd, OwnedFd)>,
-    result_sockets: (OwnedFd, OwnedFd),
-    workers: Vec<process::Child>,
+    config: Arc<config::Config>,
+    handlers: Arc<Vec<Box<dyn handlers::Processor + Send + Sync>>>,
+
+    workers: Option<Vec<thread::JoinHandle<()>>>,
+
+    job_tx: Sender<Option<Job>>,
+    answer_rx: Receiver<handlers::Stats>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Debug)]
 pub struct Job {
     selected_handlers: u8,
     input_path: PathBuf,
 }
 
 impl Controller {
-    fn build_worker_command(
-        config: &config::Config,
-        handlers: &[Box<dyn handlers::Processor>],
-        job_fd: &RawFd,
-        result_fd: &RawFd,
-    ) -> Result<process::Command> {
+    pub fn create(config: &Arc<config::Config>) -> Result<Self> {
+        let handlers = Arc::new(handlers::make_handlers(config)?);
 
-        let mut cmd = process::Command::new(env::current_exe()?);
-
-        cmd.arg("--job-socket").arg(job_fd.to_string());
-        cmd.arg("--result-socket").arg(result_fd.to_string());
-        if config.brp {
-            cmd.arg("--brp");
-        }
-        if config.verbose {
-            cmd.arg("-v");
-        }
-        if config.check {
-            cmd.arg("--check");
-        }
-        cmd.arg("--handler")
-            .arg(handlers
-                 .iter()
-                 .map(|x| x.name())
-                 .collect::<Vec<&str>>()
-                 .join(","));
-
-        if let Some(val) = config.source_date_epoch {
-            cmd.env("SOURCE_DATE_EPOCH", val.to_string());
-        }
-
-        Ok(cmd)
-    }
-
-    fn set_socket_size(fd: &OwnedFd, n: usize) -> Result<usize> {
-        /* Let's assume our messages are not larger than 4096 bytes
-         * and that we cannot push more than 256 messages into the queue. */
-        let newsize = cmp::min(n, 256) * 4096;
-
-        let mut sndbuf = sys::socket::getsockopt(fd, sys::socket::sockopt::SndBuf)?;
-        debug!("Initial socket buffer size: {sndbuf}");
-
-        if newsize > sndbuf {
-            sys::socket::setsockopt(fd, sys::socket::sockopt::SndBuf, &newsize)?;
-
-            sndbuf = sys::socket::getsockopt(fd, sys::socket::sockopt::SndBuf)?;
-            debug!("Tried to set socket buffer size to {newsize}, got {sndbuf}");
-
-            #[cfg(any(target_os = "android", target_os = "linux"))]
-            if newsize > sndbuf {
-                if let Err(err) = sys::socket::setsockopt(
-                    fd,
-                    sys::socket::sockopt::SndBufForce,
-                    &newsize,
-                ) {
-                    debug!("Cannot set buffer size to {newsize}: {err}");
-                } else {
-                    sndbuf = sys::socket::getsockopt(fd, sys::socket::sockopt::SndBuf)?;
-                    debug!("Tried to force socket buffer size to {newsize}, got {sndbuf}");
-                }
-            }
-        }
-
-        /* The kernel may set the size higher than we requested, but
-         * don't go above our initial goal. */
-        Ok(cmp::min(newsize, sndbuf) / 4096)
-    }
-
-    pub fn create(config: &Rc<config::Config>) -> Result<Self> {
-        let handlers = handlers::make_handlers(config)?;
-
-        let mut n = config.jobs.unwrap() as usize;
+        let n = config.jobs.unwrap() as usize;
         assert!(n > 0);
 
-        let job_sockets = sys::socket::socketpair(
-            sys::socket::AddressFamily::Unix,
-            sys::socket::SockType::Datagram,
-            None,
-            sys::socket::SockFlag::empty(),
-        )?;
-        let result_sockets = sys::socket::socketpair(
-            sys::socket::AddressFamily::Unix,
-            sys::socket::SockType::Datagram,
-            None,
-            sys::socket::SockFlag::empty(),
-        )?;
+        // Make the queue a little larger then the pool of workers
+        // to let a few jobs accumulate if the sender gets ahead.
+        let job_queue = crossbeam_channel::bounded(n*3/2 + 5);
+        let answer_queue = crossbeam_channel::unbounded();
 
-        fcntl::fcntl(job_sockets.1.as_raw_fd(), fcntl::F_SETFD(fcntl::FdFlag::FD_CLOEXEC))?;
-        fcntl::fcntl(result_sockets.1.as_raw_fd(), fcntl::F_SETFD(fcntl::FdFlag::FD_CLOEXEC))?;
-        fcntl::fcntl(result_sockets.1.as_raw_fd(), fcntl::F_SETFL(fcntl::OFlag::O_NONBLOCK))?;
+        let workers: Vec<_> = (0..n).map(|_| {
+            let handlers = handlers.clone();
+            let job_rx = job_queue.1.clone();
+            let answer_tx = answer_queue.0.clone();
 
-        let n2 = Self::set_socket_size(&job_sockets.0, n)?;
-        if n2 < n {
-            info!("Limiting number of workers to {n2}");
-            n = n2;
-        }
-
-        Self::set_socket_size(&result_sockets.0, n)?;
-
-        let mut cmd = Self::build_worker_command(
-            config,
-            &handlers,
-            &job_sockets.0.as_raw_fd(),
-            &result_sockets.0.as_raw_fd(),
-        )?;
-
-        let mut workers = vec![];
-        for _ in 0..n {
-            let child = cmd.spawn()?;
-            workers.push(child);
-        }
+            thread::spawn(move || {
+                do_worker_work(
+                    handlers,
+                    job_rx,
+                    answer_tx);
+            })
+        }).collect();
 
         Ok(Controller {
+            config: config.clone(),
             handlers,
-            job_sockets: Some(job_sockets),
-            result_sockets,
-            workers,
+
+            workers: Some(workers),
+
+            job_tx: job_queue.0,
+            answer_rx: answer_queue.1,
+            // The other parts of job_queue and answer_queue will be
+            // dropped when this function returns.
         })
     }
 
@@ -157,78 +73,45 @@ impl Controller {
         assert!(selected_handlers > 0);
 
         let job = Job { selected_handlers, input_path: input_path.to_path_buf() };
-        let buf = serde_cbor::ser::to_vec_packed(&job)?;
-
-        debug!("Sending {:?} ({} bytes)", &job, buf.len());
-        unistd::write(&self.job_sockets.as_ref().unwrap().1, &buf)?;
+        debug!("Sending {:?}", &job);
+        self.job_tx.send(Some(job))?;
 
         Ok(())
     }
 
     pub fn close(&mut self) -> Result<()> {
-        debug!("Sending quit command to children…");
-        for _ in &mut self.workers {
-            unistd::write(&self.job_sockets.as_ref().unwrap().1, b"")?;
+        let workers = self.workers.take().unwrap();
+
+        debug!("Sending quit command to threads…");
+        for _ in &workers {
+            self.job_tx.send(None)?;
         }
 
-        debug!("Closing control socket…");
-        self.job_sockets.take();
+        debug!("Waiting for threads to exit…");
 
-        debug!("Waiting for children to exit…");
-        for child in &mut self.workers {
-            let status = child.wait()?;
-            if status.success() {
-                debug!("Child {} exited with success", child.id());
-            } else if let Some(code) = status.code() {
-                warn!("Child {} reported error {}", child.id(), code);
-            } else if let Some(signal) = status.signal() {
-                warn!("Child {} killed by signal {}", child.id(), signal);
-            } else {
-                panic!("Child was terminated by gremlins");
+        for child in workers.into_iter() {
+            if let Err(e) = child.join() {
+                bail!("Thread failed: {e:?}");
             }
         }
-        debug!("Children are dead");
+
+        debug!("Threads are dead");
         Ok(())
     }
 
     fn read_results(&mut self, total: &mut handlers::Stats) -> Result<()> {
         debug!("Reading stats from children…");
 
-        let mut count = 0;
-        let mut buf = vec![0; 1024];
-
-        loop {
-            let n = match unistd::read(self.result_sockets.1.as_raw_fd(), &mut buf) {
-                Err(e) => {
-                    if e == errno::Errno::EAGAIN {
-                        break;
-                    } else {
-                        bail!("read failed: {e}");
-                    }
-                }
-                Ok(n) => n,
-            };
-
-            if n == 0 {
-                break;
-            }
-
-            let stats = serde_cbor::de::from_mut_slice(&mut buf[..n])?;
+        for _ in 0..self.config.jobs.unwrap() {
+            let stats = self.answer_rx.recv()?;
             debug!("Got result: {:?}", &stats);
             total.add(&stats);
-
-            count += 1;
-        }
-
-        if count != self.workers.len() {
-            error!("Got {} results from {} workers. (??)", count, self.workers.len());
-            total.errors += 1;
         }
 
         Ok(())
     }
 
-    pub fn do_work(config: &Rc<config::Config>) -> Result<handlers::Stats> {
+    pub fn do_work(config: &Arc<config::Config>) -> Result<handlers::Stats> {
         let mut control = Controller::create(config)?;
 
         let mut inodes_seen = handlers::inodes_seen();
@@ -250,7 +133,7 @@ impl Controller {
 }
 
 fn process_file_with_selected_handlers(
-    handlers: &[Box<dyn handlers::Processor>],
+    handlers: &[Box<dyn handlers::Processor + Send + Sync>],
     selected_handlers: u8,
     input_path: &Path,
 ) -> Result<handlers::ProcessResult> {
@@ -275,46 +158,28 @@ fn process_file_with_selected_handlers(
     Ok(entry_mod)
 }
 
-pub fn do_worker_work(config: &Rc<config::Config>) -> Result<()> {
-    let job_socket = config.job_socket.unwrap();
-    let job_socket = unsafe { UnixDatagram::from_raw_fd(job_socket) };
-
-    let result_socket = config.result_socket.unwrap();
-    let result_socket = unsafe { UnixDatagram::from_raw_fd(result_socket) };
-
-    let handlers = handlers::make_handlers(config)?;
+pub fn do_worker_work(
+    handlers: Arc<Vec<Box<dyn handlers::Processor + Send + Sync>>>,
+    job_rx: Receiver<Option<Job>>,
+    answer_tx: Sender<handlers::Stats>,
+) {
     let mut stats = handlers::Stats::new();
 
-    let mut buf = vec![0; 4096]; // FIXME: use a better limit here?
-
-    loop {
-        let n = match job_socket.recv(buf.as_mut_slice()) {
-            Err(e) => {
-                bail!("recv failed: {e}");
-            }
-            Ok(n) => n
-        };
-
-        if n == 0 {
-            break;
-        }
-
-        let job: Job = serde_cbor::de::from_mut_slice(&mut buf[..n])?;
+    while let Some(job) = job_rx.recv().unwrap() {
         debug!("Got job {job:?}");
-
         assert!(job.selected_handlers > 0);
 
-        let res = process_file_with_selected_handlers(
+        match process_file_with_selected_handlers(
             &handlers,
             job.selected_handlers,
-            &job.input_path)?;
-        stats.add_one(res);
+            &job.input_path)
+        {
+            Ok(res) => stats.add_one(res),
+            Err(_) => { stats.errors += 1 }
+        }
     }
 
     debug!("Wrapping up...");
-    let buf = serde_cbor::ser::to_vec_packed(&stats)?;
-    result_socket.send(&buf)?;
-
+    answer_tx.send(stats).unwrap();
     debug!("Worker says bye!");
-    Ok(())
 }

--- a/tests/test_handlers/mod.rs
+++ b/tests/test_handlers/mod.rs
@@ -11,7 +11,7 @@ use anyhow::Result;
 use std::fs;
 use std::io::{Read, Write};
 use std::path::Path;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use add_determinism::config;
 use add_determinism::handlers;
@@ -25,7 +25,7 @@ fn make_handler(
 
     init();
 
-    let cfg = Rc::new(config::Config::empty(source_date_epoch, check));
+    let cfg = Arc::new(config::Config::empty(source_date_epoch, check));
     let mut handler = func(&cfg);
     handler.initialize()?;
     Ok(handler)
@@ -34,7 +34,7 @@ fn make_handler(
 struct Trivial {}
 
 impl Trivial {
-    pub fn boxed() -> Box<dyn handlers::Processor> {
+    pub fn boxed() -> Box<dyn handlers::Processor + Send + Sync> {
         Box::new(Self {})
     }
 }
@@ -130,7 +130,7 @@ fn test_inode_map() {
 fn test_inode_map_2() {
     let (dir, _input) = prepare_dir("tests/cases/testrelro.a").unwrap();
 
-    let cfg = Rc::new(config::Config::empty(111, false));
+    let cfg = Arc::new(config::Config::empty(111, false));
     let ar = handlers::ar::Ar::boxed(&cfg);
 
     let handlers = vec![ar];

--- a/tests/test_handlers/test_ar.rs
+++ b/tests/test_handlers/test_ar.rs
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 
 use std::fs;
-use std::rc::Rc;
+use std::sync::Arc;
 #[cfg(target_os = "linux")]
 use std::os::linux::fs::MetadataExt as _;
 #[cfg(target_os = "macos")]
@@ -35,7 +35,7 @@ fn test_libempty() {
 fn test_testrelro() {
     let (_dir, input) = prepare_dir("tests/cases/testrelro.a").unwrap();
 
-    let cfg = Rc::new(config::Config::empty(111, false));
+    let cfg = Arc::new(config::Config::empty(111, false));
     let ar = ar::Ar::boxed(&cfg);
 
     assert!(ar.filter(&*input).unwrap());
@@ -55,7 +55,7 @@ fn test_testrelro() {
 fn test_testrelro_check() {
     let (_dir, input) = prepare_dir("tests/cases/testrelro.a").unwrap();
 
-    let cfg = Rc::new(config::Config::empty(111, true));
+    let cfg = Arc::new(config::Config::empty(111, true));
     let ar = ar::Ar::boxed(&cfg);
 
     assert!(ar.filter(&*input).unwrap());


### PR DESCRIPTION
Originally, add-det used processes, because the pyc worker was using an embedded python interpreter. At the time multiple embedded parallel Python VMs were considered experimental so threads were not an option. But since pyc was rewritten in Rust, there is no good reason not to use threads. Doing this allows the low-level code to serialize/deserialize the jobs and results and manipulate sockets to be dropped. All unsafe code is now gone.

Timings are similar:
```console
$ time SOURCE_DATE_EPOCH=1748901600 target/release/add-determinism.old --check /usr/share/ -j
 ...
Scanned 26149 directories and 344654 files,
               processed 72838 inodes,
               328 modified (327 replaced + 1 rewritten),
               0 unsupported format, 1 errors

old: 863.33s user 4.65s system 742% cpu 1:56.94 total
old: 937.24s user 5.06s system 734% cpu 2:08.30 total
new: 835.74s user 4.32s system 738% cpu 1:53.74 total
new: 842.84s user 4.50s system 736% cpu 1:54.98 total
```
So there's some variation, but in general the threaded version seems minimally better.

```console
$ ls -lU target/{debug,release}/add-determinism.{old,new}
 -rwxr-xr-x 1 zbyszek zbyszek 46194504 07-22 20:30 target/debug/add-determinism.old
 -rwxr-xr-x 2 zbyszek zbyszek 45175376 07-22 20:37 target/debug/add-determinism.new
 -rwxr-xr-x 1 zbyszek zbyszek  2434064 07-22 20:30 target/release/add-determinism.old
 -rwxr-xr-x 2 zbyszek zbyszek  2290272 07-22 20:38 target/release/add-determinism.new
```
200kB less in the release version is also nice.