### PR TITLE
wip: use rayon to paralellize sorting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,6 +172,7 @@ log = { version = "0.4", features = ["std"] }
 num-bigint-dig = "0.8.4"
 num-integer = "0.1.46"
 num-traits = "0.2.19"
+rayon = "1.11.0"
 regex = { version = "1.10.0", default-features = false, features = ["std", "perf", "unicode-case"] }
 rlimit = "0.10.2"
 selinux = { version = "0.4.4", optional = true }

--- a/src/linkdupes/linkfiles.rs
+++ b/src/linkdupes/linkfiles.rs
@@ -2,6 +2,7 @@
 
 use anyhow::{bail, Error, Result};
 use log::{trace, debug, info, warn};
+use rayon::prelude::*;
 
 use std::cmp::{min, Ordering};
 use std::hash::{DefaultHasher, Hasher};
@@ -513,7 +514,7 @@ pub fn process_inputs(config: &Config) -> Result<Stats> {
         process_file_or_dir(&mut files_seen, input_path, config, &mut stats)?;
     }
 
-    files_seen.sort_by(|a, b| FileInfo::compare_for_sorting(a, b, config));
+    files_seen.par_sort_unstable_by(|a, b| FileInfo::compare_for_sorting(a, b, config));
 
     link_files(files_seen, config, &mut stats)?;
 


### PR DESCRIPTION
This does not work (easily) with selinux support, because trait Sync is not implemented for NonNull<selinux_sys::selabel_handle>, and we get: error[E0277]: NonNull<selinux_sys::selabel_handle> cannot be shared between threads safely

But without selinux support, this compiles and runs nicely. But there is no gain or very little gain in wallclock time from the parallel version. On my 4-core/8-thread machine, user CPU use goes from 99% to 394%. Occasionally the wallclock time is a few percent smaller, but sometimes it is 2-3 times higher. (Maybe something with how the threads are scheduled.)  This does not seem to make sense to use the parallelized version.