### PR TITLE
Relax rlimit dependency to allow 0.11.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -173,7 +173,7 @@ num-bigint-dig = "0.8.4"
 num-integer = "0.1.46"
 num-traits = "0.2.19"
 regex = { version = "1.10.0", default-features = false, features = ["std", "perf", "unicode-case"] }
-rlimit = "0.10.2"
+rlimit = ">=0.10.2,<0.12"
 selinux = { version = "0.4.4", optional = true }
 tempfile = "3.20"
 thiserror = "1.0.61"


### PR DESCRIPTION
We need to update rlimit for coreutils 0.7.0

From the changelog the main "breaking" change is the MSRV bump, which is way below what we have in Fedora anyway

https://github.com/Nugine/rlimit/blob/main/CHANGELOG.md

(we can also just bump this to 0.11.0 but if the coreutils update is delayed and we need to cut an add-determinism update that would be problematic)