### PR TITLE
Fix clippy warnings in tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,5 +90,5 @@ jobs:
           rustup default nightly
       - name: Validate clippy
         run: |
-          cargo clippy -- -D warnings
-          cargo clippy --features selinux -- -D warnings
+          cargo clippy --all-targets -- -D warnings
+          cargo clippy --all-targets --features selinux -- -D warnings

--- a/src/add_det/config.rs
+++ b/src/add_det/config.rs
@@ -190,31 +190,31 @@ mod tests {
 
     #[test]
     fn test_filter_by_name() {
-        assert_eq!(filter_by_name("x", true, &vec!["x", "y"]), true);
-        assert_eq!(filter_by_name("x", true, &vec!["x"]), true);
-        assert_eq!(filter_by_name("x", true, &vec![]), true);
-        assert_eq!(filter_by_name("x", true, &vec!["-x"]), false);
-        assert_eq!(filter_by_name("x", true, &vec!["-y"]), true);
+        assert!(filter_by_name("x", true, &["x", "y"]));
+        assert!(filter_by_name("x", true, &["x"]));
+        assert!(filter_by_name("x", true, &[]));
+        assert!(!filter_by_name("x", true, &["-x"]));
+        assert!(filter_by_name("x", true, &["-y"]));
 
-        assert_eq!(filter_by_name("x", false, &vec!["x", "y"]), true);
-        assert_eq!(filter_by_name("x", false, &vec!["x"]), true);
-        assert_eq!(filter_by_name("x", false, &vec![]), false);
-        assert_eq!(filter_by_name("x", false, &vec!["-x"]), false);
-        assert_eq!(filter_by_name("x", false, &vec!["-y"]), false);
+        assert!(filter_by_name("x", false, &["x", "y"]));
+        assert!(filter_by_name("x", false, &["x"]));
+        assert!(!filter_by_name("x", false, &[]));
+        assert!(!filter_by_name("x", false, &["-x"]));
+        assert!(!filter_by_name("x", false, &["-y"]));
     }
 
     #[test]
     fn test_requested_handlers() {
-        let (list, strict) = requested_handlers(&vec![]).unwrap();
+        let (list, strict) = requested_handlers(&[]).unwrap();
         assert_eq!(list, vec!["ar", "jar", "javadoc", "gzip", "pyc", "zip"]);
-        assert_eq!(strict, false);
+        assert!(!strict);
 
-        let (list, strict) = requested_handlers(&vec!["ar", "pyc-zero-mtime"]).unwrap();
+        let (list, strict) = requested_handlers(&["ar", "pyc-zero-mtime"]).unwrap();
         assert_eq!(list, vec!["ar", "pyc-zero-mtime"]);
-        assert_eq!(strict, true);
+        assert!(strict);
 
-        let (list, strict) = requested_handlers(&vec!["-pyc-zero-mtime"]).unwrap();
+        let (list, strict) = requested_handlers(&["-pyc-zero-mtime"]).unwrap();
         assert_eq!(list, vec!["ar", "jar", "javadoc", "gzip", "pyc", "zip"]);
-        assert_eq!(strict, true);
+        assert!(strict);
     }
 }

--- a/src/add_det/multiprocess.rs
+++ b/src/add_det/multiprocess.rs
@@ -73,7 +73,7 @@ impl Controller {
         assert!(selected_handlers > 0);
 
         let job = Job { selected_handlers, input_path: input_path.to_path_buf() };
-        debug!("Sending {:?}", &job);
+        debug!("Sending {:?}", job);
         self.job_tx.send(Some(job))?;
 
         Ok(())
@@ -104,7 +104,7 @@ impl Controller {
 
         for _ in 0..self.config.jobs.unwrap() {
             let stats = self.answer_rx.recv()?;
-            debug!("Got result: {:?}", &stats);
+            debug!("Got result: {:?}", stats);
             total.add(&stats);
         }
 

--- a/src/linkdupes/fcontexts.rs
+++ b/src/linkdupes/fcontexts.rs
@@ -50,7 +50,7 @@ mod tests {
             Ok(labels) => labels
         };
 
-        assert_eq!(lookup_context(&labels, None, &Path::new("/")).unwrap(),
+        assert_eq!(lookup_context(&labels, None, Path::new("/")).unwrap(),
                    "system_u:object_r:root_t:s0");
     }
 }

--- a/src/linkdupes/linkfiles.rs
+++ b/src/linkdupes/linkfiles.rs
@@ -532,8 +532,8 @@ mod tests {
         let mut file1 = tempfile::NamedTempFile::new().unwrap();
         let mut file2 = tempfile::NamedTempFile::new().unwrap();
 
-        file1.write(b"0").unwrap();
-        file2.write(b"0").unwrap();
+        file1.write_all(b"0").unwrap();
+        file2.write_all(b"0").unwrap();
 
         let ts = file2.as_file().metadata().unwrap().modified().unwrap();
         file1.as_file().set_modified(ts).unwrap();
@@ -656,8 +656,8 @@ mod tests {
         let mut file1 = tempfile::NamedTempFile::new().unwrap();
         let mut file2 = tempfile::NamedTempFile::new().unwrap();
 
-        file1.write(b"0").unwrap();
-        file2.write(b"0").unwrap();
+        file1.write_all(b"0").unwrap();
+        file2.write_all(b"0").unwrap();
 
         let ts = file2.as_file().metadata().unwrap().modified().unwrap();
         file1.as_file().set_modified(ts).unwrap();
@@ -695,11 +695,11 @@ mod tests {
         let mut file1 = tempfile::NamedTempFile::new().unwrap();
         let mut file2 = tempfile::NamedTempFile::new().unwrap();
 
-        file1.write(b"0").unwrap();
-        file2.write(b"0").unwrap();
+        file1.write_all(b"0").unwrap();
+        file2.write_all(b"0").unwrap();
 
-        fs::set_permissions(file1.path(), fs::Permissions::from_mode(0u32)).unwrap();
-        fs::set_permissions(file2.path(), fs::Permissions::from_mode(0u32)).unwrap();
+        fs::set_permissions(file1.path(), fs::Permissions::from_mode(0o0u32)).unwrap();
+        fs::set_permissions(file2.path(), fs::Permissions::from_mode(0o0u32)).unwrap();
 
         let a = FileInfo {
             path: file1.path().to_path_buf(),
@@ -736,12 +736,12 @@ mod tests {
         let mut file1 = tempfile::NamedTempFile::new().unwrap();
         let mut file2 = tempfile::NamedTempFile::new().unwrap();
 
-        for (size, chunk_count) in vec![(0, 0), (4, 1), (4092, 1), (4096, 2), (4096*9, 4)] {
+        for (size, chunk_count) in [(0, 0), (4, 1), (4092, 1), (4096, 2), (4096*9, 4)] {
             if size > 0 {
                 let data = Vec::from_iter(std::iter::repeat_n(66u8, size));
-                file1.write(&data).unwrap();
+                file1.write_all(&data).unwrap();
                 file1.flush().unwrap();
-                file2.write(&data).unwrap();
+                file2.write_all(&data).unwrap();
                 file2.flush().unwrap();
             }
 

--- a/tests/handlers/mod.rs
+++ b/tests/handlers/mod.rs
@@ -55,7 +55,7 @@ impl handlers::Processor for Trivial {
 fn test_input_output_helper_drop() {
     let (_dir, input) = prepare_dir("tests/cases/libempty.a").unwrap();
 
-    let (mut helper, _) = handlers::InputOutputHelper::open(&*input, false, false).unwrap();
+    let (mut helper, _) = handlers::InputOutputHelper::open(&input, false, false).unwrap();
     helper.open_output(false).unwrap();
 
     let output_path = helper.output.as_ref().unwrap().path().to_path_buf();
@@ -69,7 +69,7 @@ fn test_input_output_helper_drop() {
 fn test_input_output_helper_drop_no_file() {
     let (_dir, input) = prepare_dir("tests/cases/libempty.a").unwrap();
 
-    let (mut helper, _) = handlers::InputOutputHelper::open(&*input, true, false).unwrap();
+    let (mut helper, _) = handlers::InputOutputHelper::open(&input, true, false).unwrap();
     helper.open_output(false).unwrap();
 
     let output_path = helper.output.as_ref().unwrap().path().to_path_buf();
@@ -166,12 +166,12 @@ fn test_corpus_file(handler: Box<dyn handlers::Processor>, filename: &str) {
                 .append(true)
                 .open(&*input)
                 .unwrap()
-                .write(&[b'x', b'y', b'_', b'_'])
+                .write_all(b"xy__")
                 .unwrap();
     }
 
-    assert!(handler.filter(&*input).unwrap());
-    assert_eq!(handler.process(&*input).unwrap(), have_mod);
+    assert!(handler.filter(&input).unwrap());
+    assert_eq!(handler.process(&input).unwrap(), have_mod);
 
     let mut data_expected = vec![];
     fs::File::open(
@@ -186,5 +186,5 @@ fn test_corpus_file(handler: Box<dyn handlers::Processor>, filename: &str) {
     assert_eq!(data_output, data_expected);
 
     // Check that rerun does not result in any modifications
-    assert_eq!(handler.process(&*input).unwrap(), handlers::ProcessResult::Noop);
+    assert_eq!(handler.process(&input).unwrap(), handlers::ProcessResult::Noop);
 }

--- a/tests/handlers/test_ar.rs
+++ b/tests/handlers/test_ar.rs
@@ -20,11 +20,11 @@ fn test_libempty() {
 
     let ar = make_handler(111, false, ar::Ar::boxed).unwrap();
 
-    assert!(ar.filter(&*input).unwrap());
+    assert!(ar.filter(&input).unwrap());
 
     let orig = input.metadata().unwrap();
 
-    assert_eq!(ar.process(&*input).unwrap(), handlers::ProcessResult::Noop);
+    assert_eq!(ar.process(&input).unwrap(), handlers::ProcessResult::Noop);
 
     let new = input.metadata().unwrap();
     assert_eq!(orig.created().unwrap(), new.created().unwrap());
@@ -39,11 +39,11 @@ fn test_testrelro() {
     let cfg = Arc::new(config::Config::empty(111, false));
     let ar = ar::Ar::boxed(&cfg);
 
-    assert!(ar.filter(&*input).unwrap());
+    assert!(ar.filter(&input).unwrap());
 
     let orig = input.metadata().unwrap();
 
-    assert_eq!(ar.process(&*input).unwrap(), handlers::ProcessResult::Replaced);
+    assert_eq!(ar.process(&input).unwrap(), handlers::ProcessResult::Replaced);
 
     let new = input.metadata().unwrap();
     // because of timestamp granularity, creation ts might be equal
@@ -59,11 +59,11 @@ fn test_testrelro_check() {
     let cfg = Arc::new(config::Config::empty(111, true));
     let ar = ar::Ar::boxed(&cfg);
 
-    assert!(ar.filter(&*input).unwrap());
+    assert!(ar.filter(&input).unwrap());
 
     let orig = input.metadata().unwrap();
 
-    assert_eq!(ar.process(&*input).unwrap(), handlers::ProcessResult::Replaced);
+    assert_eq!(ar.process(&input).unwrap(), handlers::ProcessResult::Replaced);
 
     let new = input.metadata().unwrap();
     assert_eq!(orig.created().unwrap(), new.created().unwrap());
@@ -77,13 +77,13 @@ fn test_testrelro_hardlinked() {
 
     let ar = make_handler(111, false, ar::Ar::boxed).unwrap();
 
-    assert!(ar.filter(&*input).unwrap());
+    assert!(ar.filter(&input).unwrap());
 
     let orig = input.metadata().unwrap();
 
-    fs::hard_link(&*input, (*input).with_extension("b")).unwrap();
+    fs::hard_link(&*input, input.with_extension("b")).unwrap();
 
-    assert_eq!(ar.process(&*input).unwrap(), handlers::ProcessResult::Rewritten);
+    assert_eq!(ar.process(&input).unwrap(), handlers::ProcessResult::Rewritten);
 
     let new = input.metadata().unwrap();
     assert_eq!(orig.created().unwrap(), new.created().unwrap());
@@ -97,13 +97,13 @@ fn test_testrelro_hardlinked_check() {
 
     let ar = make_handler(111, true, ar::Ar::boxed).unwrap();
 
-    assert!(ar.filter(&*input).unwrap());
+    assert!(ar.filter(&input).unwrap());
 
     let orig = input.metadata().unwrap();
 
-    fs::hard_link(&*input, (*input).with_extension("b")).unwrap();
+    fs::hard_link(&*input, input.with_extension("b")).unwrap();
 
-    assert_eq!(ar.process(&*input).unwrap(), handlers::ProcessResult::Rewritten);
+    assert_eq!(ar.process(&input).unwrap(), handlers::ProcessResult::Rewritten);
 
     let new = input.metadata().unwrap();
     assert_eq!(orig.created().unwrap(), new.created().unwrap());
@@ -117,11 +117,11 @@ fn test_testrelro_c() {
 
     let ar = make_handler(111, false, ar::Ar::boxed).unwrap();
 
-    assert!(!ar.filter(&*input).unwrap());
+    assert!(!ar.filter(&input).unwrap());
 
     let orig = input.metadata().unwrap();
 
-    assert!(ar.process(&*input).is_err());
+    assert!(ar.process(&input).is_err());
 
     let new = input.metadata().unwrap();
     assert_eq!(orig.created().unwrap(), new.created().unwrap());
@@ -135,11 +135,11 @@ fn test_testrelro_fixed() {
 
     let ar = make_handler(111, false, ar::Ar::boxed).unwrap();
 
-    assert!(ar.filter(&*input).unwrap());
+    assert!(ar.filter(&input).unwrap());
 
     let orig = input.metadata().unwrap();
 
-    assert_eq!(ar.process(&*input).unwrap(), handlers::ProcessResult::Noop);
+    assert_eq!(ar.process(&input).unwrap(), handlers::ProcessResult::Noop);
 
     let new = input.metadata().unwrap();
     assert_eq!(orig.created().unwrap(), new.created().unwrap());

--- a/tests/handlers/test_gzip.rs
+++ b/tests/handlers/test_gzip.rs
@@ -14,15 +14,15 @@ fn test_empty() {
 
     let handler = make_handler(1234567, false, gzip::Gzip::boxed).unwrap();
 
-    assert!(handler.filter(&*input).unwrap());
+    assert!(handler.filter(&input).unwrap());
 
     let orig = input.metadata().unwrap();
 
-    assert_eq!(handler.process(&*input).unwrap(), handlers::ProcessResult::Replaced);
+    assert_eq!(handler.process(&input).unwrap(), handlers::ProcessResult::Replaced);
 
     let new = input.metadata().unwrap();
     assert_eq!(orig.modified().unwrap(), new.modified().unwrap());
     assert_ne!(orig.st_ino(), new.st_ino());
 
-    assert_eq!(handler.process(&*input).unwrap(), handlers::ProcessResult::Noop);
+    assert_eq!(handler.process(&input).unwrap(), handlers::ProcessResult::Noop);
 }

--- a/tests/handlers/test_javadoc.rs
+++ b/tests/handlers/test_javadoc.rs
@@ -18,11 +18,11 @@ fn test_javadoc_example() {
 
     let javadoc = make_handler(1704106800, false, javadoc::Javadoc::boxed).unwrap();
 
-    assert!(javadoc.filter(&*input).unwrap());
+    assert!(javadoc.filter(&input).unwrap());
 
     let orig = input.metadata().unwrap();
 
-    assert_eq!(javadoc.process(&*input).unwrap(), handlers::ProcessResult::Replaced);
+    assert_eq!(javadoc.process(&input).unwrap(), handlers::ProcessResult::Replaced);
 
     let new = input.metadata().unwrap();
     // because of timestamp granularity, creation ts might be equal
@@ -40,11 +40,11 @@ fn test_javadoc_fixed() {
 
     let javadoc = make_handler(1704106800, false, javadoc::Javadoc::boxed).unwrap();
 
-    assert!(javadoc.filter(&*input).unwrap());
+    assert!(javadoc.filter(&input).unwrap());
 
     let orig = input.metadata().unwrap();
 
-    assert_eq!(javadoc.process(&*input).unwrap(), handlers::ProcessResult::Noop);
+    assert_eq!(javadoc.process(&input).unwrap(), handlers::ProcessResult::Noop);
 
     let new = input.metadata().unwrap();
     assert_eq!(orig.created().unwrap(), new.created().unwrap());
@@ -58,11 +58,11 @@ fn test_invalid_utf8() {
 
     let javadoc = make_handler(1704106800, false, javadoc::Javadoc::boxed).unwrap();
 
-    assert!(javadoc.filter(&*input).unwrap());
+    assert!(javadoc.filter(&input).unwrap());
 
     let orig = input.metadata().unwrap();
 
-    assert_eq!(javadoc.process(&*input).unwrap(), handlers::ProcessResult::Noop);
+    assert_eq!(javadoc.process(&input).unwrap(), handlers::ProcessResult::Noop);
 
     let new = input.metadata().unwrap();
     assert_eq!(orig.created().unwrap(), new.created().unwrap());

--- a/tests/handlers/test_pyc.rs
+++ b/tests/handlers/test_pyc.rs
@@ -60,11 +60,11 @@ fn test_adapters() {
 
     let pyc = make_handler(111, false, pyc::Pyc::boxed).unwrap();
 
-    assert!(pyc.filter(&*input).unwrap());
+    assert!(pyc.filter(&input).unwrap());
 
     let orig = input.metadata().unwrap();
 
-    assert_eq!(pyc.process(&*input).unwrap(), handlers::ProcessResult::Replaced);
+    assert_eq!(pyc.process(&input).unwrap(), handlers::ProcessResult::Replaced);
 
     let new = input.metadata().unwrap();
     // because of timestamp granularity, creation ts might be equal
@@ -79,11 +79,11 @@ fn test_adapters_hardlinked() {
 
     let pyc = make_handler(111, false, pyc::Pyc::boxed).unwrap();
 
-    assert!(pyc.filter(&*input).unwrap());
+    assert!(pyc.filter(&input).unwrap());
 
     let orig = input.metadata().unwrap();
 
-    fs::hard_link(&*input, (*input).with_extension("pyc.evenbetter")).unwrap();
+    fs::hard_link(&*input, input.with_extension("pyc.evenbetter")).unwrap();
 
     let mut data_expected = vec![];
     File::open("tests/cases/adapters.cpython-312~fixed.pyc")
@@ -91,7 +91,7 @@ fn test_adapters_hardlinked() {
         .read_to_end(&mut data_expected)
         .unwrap();
 
-    assert_eq!(pyc.process(&*input).unwrap(), handlers::ProcessResult::Rewritten);
+    assert_eq!(pyc.process(&input).unwrap(), handlers::ProcessResult::Rewritten);
 
     let new = input.metadata().unwrap();
     assert_eq!(orig.created().unwrap(), new.created().unwrap());
@@ -111,11 +111,11 @@ fn test_adapters_opt_1() {
 
     let pyc = make_handler(111, false, pyc::Pyc::boxed).unwrap();
 
-    assert!(pyc.filter(&*input).unwrap());
+    assert!(pyc.filter(&input).unwrap());
 
     let orig = input.metadata().unwrap();
 
-    assert_eq!(pyc.process(&*input).unwrap(), handlers::ProcessResult::Replaced);
+    assert_eq!(pyc.process(&input).unwrap(), handlers::ProcessResult::Replaced);
 
     let new = input.metadata().unwrap();
     // because of timestamp granularity, creation ts might be equal
@@ -131,11 +131,11 @@ fn test_adapters_fixed() {
 
     let pyc = make_handler(111, false, pyc::Pyc::boxed).unwrap();
 
-    assert!(pyc.filter(&*input).unwrap());
+    assert!(pyc.filter(&input).unwrap());
 
     let orig = input.metadata().unwrap();
 
-    assert_eq!(pyc.process(&*input).unwrap(), handlers::ProcessResult::Noop);
+    assert_eq!(pyc.process(&input).unwrap(), handlers::ProcessResult::Noop);
 
     let new = input.metadata().unwrap();
     assert_eq!(orig.created().unwrap(), new.created().unwrap());

--- a/tests/handlers/test_pyc_zero_mtime.rs
+++ b/tests/handlers/test_pyc_zero_mtime.rs
@@ -27,11 +27,11 @@ fn test_adapters() {
 
     let pyc = make_handler(111, false, handlers::pyc::PycZeroMtime::boxed).unwrap();
 
-    assert!(pyc.filter(&*input).unwrap());
+    assert!(pyc.filter(&input).unwrap());
 
     let orig = input.metadata().unwrap();
 
-    assert_eq!(pyc.process(&*input).unwrap(), handlers::ProcessResult::Replaced);
+    assert_eq!(pyc.process(&input).unwrap(), handlers::ProcessResult::Replaced);
 
     let new = input.metadata().unwrap();
     // because of timestamp granularity, creation ts might be equal


### PR DESCRIPTION
I noticed there are some clippy warnings in tests, the assert/assert_eq and dereference warnings don't matter much, but `File::write` vs `File::write_all` could lead to silent partial writes and hard to debug tests.

To reproduce, use `cargo clippy --all-targets`